### PR TITLE
Implement `max_task_count` for worker

### DIFF
--- a/pyzeebe/task/task_builder.py
+++ b/pyzeebe/task/task_builder.py
@@ -23,15 +23,17 @@ def build_job_handler(task_function: Callable, task_config: TaskConfig) -> JobHa
     before_decorator_runner = create_decorator_runner(task_config.before)
     after_decorator_runner = create_decorator_runner(task_config.after)
 
-    def job_handler(job: Job, task_state: TaskState) -> Job:
-        task_state.add(job)
+    def job_handler(job: Job, task_state: TaskState = None) -> Job:
+        if task_state:
+            task_state.add(job)
         job = before_decorator_runner(job)
         job.variables, succeeded = run_original_task_function(
             task_function, task_config, job)
         job = after_decorator_runner(job)
         if succeeded:
             job.set_success_status()
-        task_state.remove(job)
+        if task_state:
+            task_state.remove(job)
         return job
 
     return job_handler

--- a/pyzeebe/task/task_builder.py
+++ b/pyzeebe/task/task_builder.py
@@ -6,6 +6,7 @@ from pyzeebe import Job, TaskDecorator
 from pyzeebe.task.task import Task
 from pyzeebe.task.task_config import TaskConfig
 from pyzeebe.task.types import DecoratorRunner, JobHandler
+from pyzeebe.worker.task_state import TaskState
 
 logger = logging.getLogger(__name__)
 
@@ -22,13 +23,15 @@ def build_job_handler(task_function: Callable, task_config: TaskConfig) -> JobHa
     before_decorator_runner = create_decorator_runner(task_config.before)
     after_decorator_runner = create_decorator_runner(task_config.after)
 
-    def job_handler(job: Job) -> Job:
+    def job_handler(job: Job, task_state: TaskState) -> Job:
+        task_state.add(job)
         job = before_decorator_runner(job)
         job.variables, succeeded = run_original_task_function(
             task_function, task_config, job)
         job = after_decorator_runner(job)
         if succeeded:
             job.set_success_status()
+        task_state.remove(job)
         return job
 
     return job_handler

--- a/pyzeebe/worker/task_state.py
+++ b/pyzeebe/worker/task_state.py
@@ -1,0 +1,22 @@
+import logging
+from pyzeebe import Job
+
+logger = logging.getLogger(__name__)
+
+class TaskState:
+    def __init__(self):
+        self._data = set()
+
+    def remove(self, job: Job) -> None:
+        try:
+            self._data.remove(job.key)
+        except KeyError:
+            logger.warning(f"Could not find Job key {job.key} when trying to remove from TaskState")
+
+    def add(self, job: Job) -> None:
+        if job.key in self._data:
+            raise ValueError(f"Job {job.key} already registered in TaskState")
+        self._data.add(job.key)
+
+    def count_active(self) -> int:
+        return len(self._data)

--- a/pyzeebe/worker/worker.py
+++ b/pyzeebe/worker/worker.py
@@ -11,6 +11,7 @@ from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
 from pyzeebe.job.job import Job
 from pyzeebe.task.task import Task
 from pyzeebe.worker.task_router import ZeebeTaskRouter
+from pyzeebe.worker.task_state import TaskState
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,8 @@ class ZeebeWorker(ZeebeTaskRouter):
     def __init__(self, name: str = None, request_timeout: int = 0, hostname: str = None, port: int = None,
                  credentials: BaseCredentials = None, secure_connection: bool = False,
                  before: List[TaskDecorator] = None, after: List[TaskDecorator] = None,
-                 max_connection_retries: int = 10, watcher_max_errors_factor: int = 3):
+                 max_connection_retries: int = 10, watcher_max_errors_factor: int = 3,
+                 max_task_count: int = 4):
         """
         Args:
             hostname (str): Zeebe instance hostname
@@ -32,6 +34,7 @@ class ZeebeWorker(ZeebeTaskRouter):
             after (List[TaskDecorator]): Decorators to be performed after each task
             max_connection_retries (int): Amount of connection retries before worker gives up on connecting to zeebe. To setup with infinite retries use -1
             watcher_max_errors_factor (int): Number of consequtive errors for a task watcher will accept before raising MaxConsecutiveTaskThreadError
+            max_task_count (int): The maximum amount of tasks the worker can handle simultaniously
         """
         super().__init__(before, after)
         self.zeebe_adapter = ZeebeAdapter(hostname=hostname, port=port, credentials=credentials,
@@ -43,6 +46,8 @@ class ZeebeWorker(ZeebeTaskRouter):
         self._task_threads: Dict[str, Thread] = {}
         self.watcher_max_errors_factor = watcher_max_errors_factor
         self._watcher_thread = None
+        self.max_task_count = max_task_count
+        self._task_state = TaskState()
 
     def work(self, watch: bool = False) -> None:
         """
@@ -170,15 +175,20 @@ class ZeebeWorker(ZeebeTaskRouter):
     def _handle_jobs(self, task: Task) -> None:
         for job in self._get_jobs(task):
             thread = Thread(target=task.job_handler,
-                            args=(job,),
+                            args=(job, self._task_state),
                             name=f"{self.__class__.__name__}-Job-{job.type}")
             logger.debug(f"Running job: {job}")
             thread.start()
 
+    def _calculate_max_jobs_to_activate(self, max_jobs_to_activate_config: int) -> int:
+        worker_max_jobs = int(self.max_task_count) - self._task_state.count_active()
+        return min(worker_max_jobs, max_jobs_to_activate_config)
+
     def _get_jobs(self, task: Task) -> Generator[Job, None, None]:
         logger.debug(f"Activating jobs for task: {task}")
+        max_jobs_to_activate = self._calculate_max_jobs_to_activate(task.config.max_jobs_to_activate)
         return self.zeebe_adapter.activate_jobs(task_type=task.type, worker=self.name, timeout=task.config.timeout_ms,
-                                                max_jobs_to_activate=task.config.max_jobs_to_activate,
+                                                max_jobs_to_activate=max_jobs_to_activate,
                                                 variables_to_fetch=task.config.variables_to_fetch,
                                                 request_timeout=self.request_timeout)
 

--- a/tests/unit/worker/task_state_test.py
+++ b/tests/unit/worker/task_state_test.py
@@ -1,0 +1,34 @@
+import pytest
+from pyzeebe.worker.task_state import TaskState
+
+
+@pytest.fixture
+def task_state():
+    return TaskState()
+
+
+def test_new_task_state_has_0_active_jobs(task_state):
+    assert task_state.count_active() == 0
+
+
+def test_add_counts_as_active(task_state, job_from_task):
+    task_state.add(job_from_task)
+    assert task_state.count_active() == 1
+
+
+def test_add_then_remove_results_in_0_active(task_state, job_from_task):
+    task_state.add(job_from_task)
+    task_state.remove(job_from_task)
+    assert task_state.count_active() == 0
+
+
+def test_prevents_adding_duplicate_job(task_state, job_from_task):
+    with pytest.raises(ValueError) as exc_info:
+        for _ in range(2):
+            task_state.add(job_from_task)
+    assert exc_info.value.args[0].endswith("already registered in TaskState")
+
+
+def test_remove_non_existing_job_dont_withdraw_from_active_jobs(task_state, job_from_task):
+    task_state.remove(job_from_task)
+    assert task_state.count_active() == 0

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -218,7 +218,7 @@ class TestWorkerMaxTasks:
 
         zeebe_worker._get_jobs(task)
 
-        assert activate_job_mock.call_args.kwargs["max_jobs_to_activate"] == expected
+        assert activate_job_mock.call_args[1]["max_jobs_to_activate"] == expected
 
     def test_activating_jobs_increase_and_decrease_active_task_count(self, zeebe_worker: ZeebeWorker,
                                                                      job_from_task: Job, task: Task):

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -92,7 +92,7 @@ class TestHandleJobs:
 
         zeebe_worker._handle_jobs(task)
 
-        task.job_handler.assert_called_with(job_from_task)
+        task.job_handler.assert_called_with(job_from_task, zeebe_worker._task_state)
 
     def test_handle_many_jobs(self, zeebe_worker: ZeebeWorker, task: Task, job_from_task: Job,
                               get_jobs_mock: MagicMock):
@@ -159,7 +159,7 @@ class TestGetJobs:
         zeebe_worker._get_jobs(task)
         zeebe_worker.zeebe_adapter.activate_jobs.assert_called_with(task_type=task.type, worker=zeebe_worker.name,
                                                                     timeout=task.config.timeout_ms,
-                                                                    max_jobs_to_activate=task.config.max_jobs_to_activate,
+                                                                    max_jobs_to_activate=zeebe_worker.max_task_count,
                                                                     variables_to_fetch=task.config.variables_to_fetch,
                                                                     request_timeout=zeebe_worker.request_timeout)
 


### PR DESCRIPTION
Implement `max_task_count` for worker. 

## Changes

- By default, the worker will handle at max 4 concurrent tasks, this can be changed by initialising the worker by setting `max_task_count` or setting it after initialisation. 

## API Updates

### New Features *(required)*

The worker will track the number of currently running tasks, and prevent that more than _n_ running tasks (4 by default) are running concurrently. 

This feature is intended for workers where there might be some resource constrains (e.g. running more than 4 tasks will exhaust available CPU/RAM).  

### Deprecations *(required)*

n/a

### Enhancements *(optional)*

n/a

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #103 