### PR TITLE
Add missing grpc arguments

### DIFF
--- a/examples/worker.py
+++ b/examples/worker.py
@@ -4,6 +4,9 @@ from pyzeebe import Job, ZeebeWorker, CamundaCloudCredentials
 
 
 # Use decorators to add functionality before and after tasks. These will not fail the task
+from pyzeebe.exceptions import BusinessException
+
+
 def example_logging_task_decorator(job: Job) -> Job:
     print(job)
     return job
@@ -35,6 +38,14 @@ def example_task() -> Dict:
 @worker.task(task_type="add_one", single_value=True, variable_name="y")  # This task will return to zeebe: { y: x + 1 }
 def add_one(x) -> int:
     return x + 1
+
+
+# The default exception handler will call job.set_error_status
+# on raised BusinessException, and propagate its error_code
+# so the specific business error can be caught in the Zeebe workflow
+@worker.task(task_type="business_exception_task")
+def exception_task():
+    raise BusinessException("invalid-credit-card")
 
 
 # Define a custom exception_handler for a task like so:

--- a/pyzeebe/exceptions/pyzeebe_exceptions.py
+++ b/pyzeebe/exceptions/pyzeebe_exceptions.py
@@ -23,3 +23,16 @@ class DuplicateTaskType(PyZeebeException):
 
 class MaxConsecutiveTaskThreadError(PyZeebeException):
     pass
+
+
+class BusinessException(PyZeebeException):
+    """
+    Exception that can be raised with a user defined code,
+    to be caught later by an error event in the workflow
+    """
+    def __init__(self, error_code: str) -> None:
+        super().__init__(f"Business error with code {error_code}")
+        self.error_code = error_code
+
+    def __repr__(self) -> str:
+        return str({"error_code": self.error_code})

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -68,10 +68,10 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             else:
                 self._common_zeebe_grpc_errors(rpc_error)
 
-    def throw_error(self, job_key: int, message: str) -> ThrowErrorResponse:
+    def throw_error(self, job_key: int, message: str, error_code: str = None) -> ThrowErrorResponse:
         try:
             return self._gateway_stub.ThrowError(
-                ThrowErrorRequest(jobKey=job_key, errorMessage=message))
+                ThrowErrorRequest(jobKey=job_key, errorMessage=message, errorCode=error_code))
         except grpc.RpcError as rpc_error:
             if self.is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
                 raise JobNotFound(job_key=job_key)

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -57,9 +57,9 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             else:
                 self._common_zeebe_grpc_errors(rpc_error)
 
-    def fail_job(self, job_key: int, message: str) -> FailJobResponse:
+    def fail_job(self, job_key: int, retries: int, message: str) -> FailJobResponse:
         try:
-            return self._gateway_stub.FailJob(FailJobRequest(jobKey=job_key, errorMessage=message))
+            return self._gateway_stub.FailJob(FailJobRequest(jobKey=job_key, retries=retries, errorMessage=message))
         except grpc.RpcError as rpc_error:
             if self.is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
                 raise JobNotFound(job_key=job_key)

--- a/pyzeebe/job/job.py
+++ b/pyzeebe/job/job.py
@@ -57,7 +57,7 @@ class Job(object):
 
         """
         if self.zeebe_adapter:
-            self.zeebe_adapter.fail_job(job_key=self.key, message=message)
+            self.zeebe_adapter.fail_job(job_key=self.key, retries=self.retries, message=message)
         else:
             raise NoZeebeAdapter()
 

--- a/pyzeebe/job/job.py
+++ b/pyzeebe/job/job.py
@@ -61,13 +61,15 @@ class Job(object):
         else:
             raise NoZeebeAdapter()
 
-    def set_error_status(self, message: str) -> None:
+    def set_error_status(self, message: str, error_code: str = None) -> None:
         """
         Error status means that the job could not be completed because of a business error and won't ever be able to be completed.
         For example: a required parameter was not given
+        An error code can be added to handle the error in the workflow
 
         Args:
-            message (str): The error message that Zeebe will receive
+            message (str): The error message
+            error_code (str): The error code that Zeebe will receive
 
         Raises:
             NoZeebeAdapter: If the job does not have a configured ZeebeAdapter
@@ -77,7 +79,7 @@ class Job(object):
 
         """
         if self.zeebe_adapter:
-            self.zeebe_adapter.throw_error(job_key=self.key, message=message)
+            self.zeebe_adapter.throw_error(job_key=self.key, message=message, error_code=error_code)
         else:
             raise NoZeebeAdapter()
 

--- a/pyzeebe/worker/task_handler.py
+++ b/pyzeebe/worker/task_handler.py
@@ -3,7 +3,7 @@ from abc import abstractmethod
 from typing import Tuple, List, Callable, Dict
 
 from pyzeebe.decorators.zeebe_decorator_base import ZeebeDecoratorBase
-from pyzeebe.exceptions import NoVariableNameGiven, TaskNotFound, DuplicateTaskType
+from pyzeebe.exceptions import NoVariableNameGiven, TaskNotFound, DuplicateTaskType, BusinessException
 from pyzeebe.job.job import Job
 from pyzeebe.task.exception_handler import ExceptionHandler
 from pyzeebe.task.task import Task
@@ -14,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 def default_exception_handler(e: Exception, job: Job) -> None:
     logger.warning(f"Task type: {job.type} - failed job {job}. Error: {e}.")
-    job.set_failure_status(f"Failed job. Error: {e}")
+    if isinstance(e, BusinessException):
+        job.set_error_status(f"Failed job. Recoverable error: {e}", error_code=e.error_code)
+    else:
+        job.set_failure_status(f"Failed job. Error: {e}")
 
 
 class ZeebeTaskHandler(ZeebeDecoratorBase):

--- a/tests/unit/grpc_internals/zeebe_job_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_job_adapter_test.py
@@ -119,21 +119,21 @@ def test_complete_job_common_errors_called(zeebe_adapter, grpc_servicer):
 def test_fail_job(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
     job = get_first_active_job(task_type, zeebe_adapter)
-    response = zeebe_adapter.fail_job(job_key=job.key, message=str(uuid4()))
+    response = zeebe_adapter.fail_job(job_key=job.key, retries=job.retries, message=str(uuid4()))
     assert isinstance(response, FailJobResponse)
 
 
 def test_fail_job_not_found(zeebe_adapter):
     with pytest.raises(JobNotFound):
-        zeebe_adapter.fail_job(job_key=randint(0, RANDOM_RANGE), message=str(uuid4()))
+        zeebe_adapter.fail_job(job_key=randint(0, RANDOM_RANGE), retries=1, message=str(uuid4()))
 
 
 def test_fail_job_already_failed(zeebe_adapter, grpc_servicer):
     task_type = create_random_task_and_activate(grpc_servicer)
     job = get_first_active_job(task_type, zeebe_adapter)
-    zeebe_adapter.fail_job(job_key=job.key, message=str(uuid4()))
+    zeebe_adapter.fail_job(job_key=job.key, retries=job.retries, message=str(uuid4()))
     with pytest.raises(JobAlreadyDeactivated):
-        zeebe_adapter.fail_job(job_key=job.key, message=str(uuid4()))
+        zeebe_adapter.fail_job(job_key=job.key, retries=job.retries, message=str(uuid4()))
 
 
 def test_fail_job_common_errors_called(zeebe_adapter, grpc_servicer):
@@ -145,7 +145,7 @@ def test_fail_job_common_errors_called(zeebe_adapter, grpc_servicer):
 
     task_type = create_random_task_and_activate(grpc_servicer)
     job = get_first_active_job(task_type, zeebe_adapter)
-    zeebe_adapter.fail_job(job_key=job.key, message=str(uuid4()))
+    zeebe_adapter.fail_job(job_key=job.key, retries=job.retries, message=str(uuid4()))
 
     zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 

--- a/tests/unit/job/job_test.py
+++ b/tests/unit/job/job_test.py
@@ -42,7 +42,7 @@ def test_failure(job_with_adapter):
     with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.fail_job") as fail_job_mock:
         message = str(uuid4())
         job_with_adapter.set_failure_status(message)
-        fail_job_mock.assert_called_with(job_key=job_with_adapter.key, message=message)
+        fail_job_mock.assert_called_with(job_key=job_with_adapter.key, retries=job_with_adapter.retries, message=message)
 
 
 def test_failure_no_zeebe_adapter(job_without_adapter):

--- a/tests/unit/job/job_test.py
+++ b/tests/unit/job/job_test.py
@@ -21,7 +21,15 @@ def test_error(job_with_adapter):
     with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.throw_error") as throw_error_mock:
         message = str(uuid4())
         job_with_adapter.set_error_status(message)
-        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message)
+        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code=None)
+
+
+def test_error_with_code(job_with_adapter):
+    with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.throw_error") as throw_error_mock:
+        message = str(uuid4())
+        error_code = "custom-error-code"
+        job_with_adapter.set_error_status(message, error_code)
+        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code=error_code)
 
 
 def test_error_no_zeebe_adapter(job_without_adapter):


### PR DESCRIPTION
Add ability to specify an errorCode when throwing an error from a task, for later handling in Zeebe workflow. While working on that, I also noticed that the `retries` attribute of a `Job` object was never actually used and so a job was never set to be retried after a call to `set_failure_status`, I fixed that.

## Changes

- Fill `errorCode` argument when constructing a `ThrowErrorRequest`
- Fill `retries` argument when constructing a `FailJobRequest`

## API Updates

### New Features

- Add a `BusinessException` class with an `error_code` argument. This exception can be raised from a task to indicate that it failed with an anticipated  error handled in workflow.

### Enhancements

- `Job.set_error_status` now accepts an `error_code` argument. Same goes for `ZeebeJobAdapter.throw_error`.
- `default_exception_handler` now calls `Job.set_error_status` when the exception is a `BusinessException`
- `ZeebeJobAdapter.fail_job` now accepts a retries argument. `Job.set_failure_status` pass the `Job.retries` to it.

## Checklist

- [X ] Unit tests
- [X ] Documentation

## References

Fixes #162
