### PR TITLE
Pre release/add missing grpc arguments

### DIFF
--- a/examples/worker.py
+++ b/examples/worker.py
@@ -4,7 +4,7 @@ from pyzeebe import Job, ZeebeWorker, CamundaCloudCredentials
 
 
 # Use decorators to add functionality before and after tasks. These will not fail the task
-from pyzeebe.exceptions import BusinessException
+from pyzeebe.errors import BusinessError
 
 
 def example_logging_task_decorator(job: Job) -> Job:
@@ -41,11 +41,11 @@ def add_one(x) -> int:
 
 
 # The default exception handler will call job.set_error_status
-# on raised BusinessException, and propagate its error_code
-# so the specific business error can be caught in the Zeebe workflow
+# on raised BusinessError, and propagate its error_code
+# so the specific business error can be caught in the Zeebe process
 @worker.task(task_type="business_exception_task")
 def exception_task():
-    raise BusinessException("invalid-credit-card")
+    raise BusinessError("invalid-credit-card")
 
 
 # Define a custom exception_handler for a task like so:

--- a/examples/worker.py
+++ b/examples/worker.py
@@ -4,6 +4,9 @@ from pyzeebe import Job, ZeebeWorker, CamundaCloudCredentials
 
 
 # Use decorators to add functionality before and after tasks. These will not fail the task
+from pyzeebe.exceptions import BusinessException
+
+
 def example_logging_task_decorator(job: Job) -> Job:
     print(job)
     return job
@@ -35,6 +38,14 @@ def example_task() -> Dict:
 @worker.task(task_type="add_one", single_value=True, variable_name="y")  # This task will return to zeebe: { y: x + 1 }
 def add_one(x) -> int:
     return x + 1
+
+
+# The default exception handler will call job.set_error_status
+# on raised BusinessException, and propagate its error_code
+# so the specific business error can be caught in the Zeebe workflow
+@worker.task(task_type="business_exception_task")
+def exception_task():
+    raise BusinessException("invalid-credit-card")
 
 
 # Define a custom exception_handler for a task like so:

--- a/pyzeebe/errors/pyzeebe_errors.py
+++ b/pyzeebe/errors/pyzeebe_errors.py
@@ -31,9 +31,9 @@ class BusinessError(PyZeebeError):
     Exception that can be raised with a user defined code,
     to be caught later by an error event in the Zeebe process
     """
-    def __init__(self, error_code: str) -> None:
-        super().__init__(f"Business error with code {error_code}")
-        self.error_code = error_code
 
-    def __repr__(self) -> str:
-        return str({"error_code": self.error_code})
+    def __init__(self, error_code: str, msg: str = None) -> None:
+        if msg is None:
+            msg = f"Business error with code {error_code}"
+        super().__init__(msg)
+        self.error_code = error_code

--- a/pyzeebe/errors/pyzeebe_errors.py
+++ b/pyzeebe/errors/pyzeebe_errors.py
@@ -24,3 +24,16 @@ class DuplicateTaskTypeError(PyZeebeError):
 
 class MaxConsecutiveTaskThreadError(PyZeebeError):
     pass
+
+
+class BusinessException(PyZeebeException):
+    """
+    Exception that can be raised with a user defined code,
+    to be caught later by an error event in the workflow
+    """
+    def __init__(self, error_code: str) -> None:
+        super().__init__(f"Business error with code {error_code}")
+        self.error_code = error_code
+
+    def __repr__(self) -> str:
+        return str({"error_code": self.error_code})

--- a/pyzeebe/errors/pyzeebe_errors.py
+++ b/pyzeebe/errors/pyzeebe_errors.py
@@ -26,10 +26,10 @@ class MaxConsecutiveTaskThreadError(PyZeebeError):
     pass
 
 
-class BusinessException(PyZeebeException):
+class BusinessError(PyZeebeError):
     """
     Exception that can be raised with a user defined code,
-    to be caught later by an error event in the workflow
+    to be caught later by an error event in the Zeebe process
     """
     def __init__(self, error_code: str) -> None:
         super().__init__(f"Business error with code {error_code}")

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -68,10 +68,10 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             else:
                 self._common_zeebe_grpc_errors(rpc_error)
 
-    def throw_error(self, job_key: int, message: str) -> ThrowErrorResponse:
+    def throw_error(self, job_key: int, message: str, error_code: str = None) -> ThrowErrorResponse:
         try:
             return self._gateway_stub.ThrowError(
-                ThrowErrorRequest(jobKey=job_key, errorMessage=message))
+                ThrowErrorRequest(jobKey=job_key, errorMessage=message, errorCode=error_code))
         except grpc.RpcError as rpc_error:
             if self.is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
                 raise JobNotFoundError(job_key=job_key)

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -68,7 +68,7 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             else:
                 self._common_zeebe_grpc_errors(rpc_error)
 
-    def throw_error(self, job_key: int, message: str, error_code: str = None) -> ThrowErrorResponse:
+    def throw_error(self, job_key: int, message: str, error_code: str = "") -> ThrowErrorResponse:
         try:
             return self._gateway_stub.ThrowError(
                 ThrowErrorRequest(jobKey=job_key, errorMessage=message, errorCode=error_code))

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -57,9 +57,9 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             else:
                 self._common_zeebe_grpc_errors(rpc_error)
 
-    def fail_job(self, job_key: int, message: str) -> FailJobResponse:
+    def fail_job(self, job_key: int, retries: int, message: str) -> FailJobResponse:
         try:
-            return self._gateway_stub.FailJob(FailJobRequest(jobKey=job_key, errorMessage=message))
+            return self._gateway_stub.FailJob(FailJobRequest(jobKey=job_key, retries=retries, errorMessage=message))
         except grpc.RpcError as rpc_error:
             if self.is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
                 raise JobNotFoundError(job_key=job_key)

--- a/pyzeebe/job/job.py
+++ b/pyzeebe/job/job.py
@@ -62,13 +62,15 @@ class Job(object):
         else:
             raise NoZeebeAdapterError()
 
-    def set_error_status(self, message: str) -> None:
+    def set_error_status(self, message: str, error_code: str = None) -> None:
         """
         Error status means that the job could not be completed because of a business error and won't ever be able to be completed.
         For example: a required parameter was not given
+        An error code can be added to handle the error in the workflow
 
         Args:
-            message (str): The error message that Zeebe will receive
+            message (str): The error message
+            error_code (str): The error code that Zeebe will receive
 
         Raises:
             NoZeebeAdapterError: If the job does not have a configured ZeebeAdapter
@@ -78,7 +80,7 @@ class Job(object):
 
         """
         if self.zeebe_adapter:
-            self.zeebe_adapter.throw_error(job_key=self.key, message=message)
+            self.zeebe_adapter.throw_error(job_key=self.key, message=message, error_code=error_code)
         else:
             raise NoZeebeAdapterError()
 

--- a/pyzeebe/job/job.py
+++ b/pyzeebe/job/job.py
@@ -58,11 +58,11 @@ class Job(object):
 
         """
         if self.zeebe_adapter:
-            self.zeebe_adapter.fail_job(job_key=self.key, retries=self.retries, message=message)
+            self.zeebe_adapter.fail_job(job_key=self.key, retries=self.retries-1, message=message)
         else:
             raise NoZeebeAdapterError()
 
-    def set_error_status(self, message: str, error_code: str = None) -> None:
+    def set_error_status(self, message: str, error_code: str = "") -> None:
         """
         Error status means that the job could not be completed because of a business error and won't ever be able to be completed.
         For example: a required parameter was not given

--- a/pyzeebe/job/job.py
+++ b/pyzeebe/job/job.py
@@ -58,7 +58,7 @@ class Job(object):
 
         """
         if self.zeebe_adapter:
-            self.zeebe_adapter.fail_job(job_key=self.key, message=message)
+            self.zeebe_adapter.fail_job(job_key=self.key, retries=self.retries, message=message)
         else:
             raise NoZeebeAdapterError()
 
@@ -66,7 +66,7 @@ class Job(object):
         """
         Error status means that the job could not be completed because of a business error and won't ever be able to be completed.
         For example: a required parameter was not given
-        An error code can be added to handle the error in the workflow
+        An error code can be added to handle the error in the Zeebe process
 
         Args:
             message (str): The error message

--- a/pyzeebe/worker/task_router.py
+++ b/pyzeebe/worker/task_router.py
@@ -3,7 +3,7 @@ from typing import Callable, List, Tuple, Optional
 
 from pyzeebe import TaskDecorator
 from pyzeebe.errors import (DuplicateTaskTypeError, NoVariableNameGivenError,
-                            TaskNotFoundError)
+                            TaskNotFoundError, BusinessError)
 from pyzeebe.job.job import Job
 from pyzeebe.task import task_builder
 from pyzeebe.task.exception_handler import ExceptionHandler
@@ -15,7 +15,10 @@ logger = logging.getLogger(__name__)
 
 def default_exception_handler(e: Exception, job: Job) -> None:
     logger.warning(f"Task type: {job.type} - failed job {job}. Error: {e}.")
-    job.set_failure_status(f"Failed job. Error: {e}")
+    if isinstance(e, BusinessError):
+        job.set_error_status(f"Failed job. Recoverable error: {e}", error_code=e.error_code)
+    else:
+        job.set_failure_status(f"Failed job. Error: {e}")
 
 
 class ZeebeTaskRouter:

--- a/tests/unit/grpc_internals/zeebe_job_adapter_test.py
+++ b/tests/unit/grpc_internals/zeebe_job_adapter_test.py
@@ -105,19 +105,19 @@ def test_complete_job_common_errors_called(zeebe_adapter, first_active_job: Job)
 
 
 def test_fail_job(zeebe_adapter, first_active_job: Job):
-    response = zeebe_adapter.fail_job(job_key=first_active_job.key, message=str(uuid4()))
+    response = zeebe_adapter.fail_job(job_key=first_active_job.key, retries=first_active_job.retries, message=str(uuid4()))
     assert isinstance(response, FailJobResponse)
 
 
 def test_fail_job_not_found(zeebe_adapter):
     with pytest.raises(JobNotFoundError):
-        zeebe_adapter.fail_job(job_key=randint(0, RANDOM_RANGE), message=str(uuid4()))
+        zeebe_adapter.fail_job(job_key=randint(0, RANDOM_RANGE), retries=1, message=str(uuid4()))
 
 
 def test_fail_job_already_failed(zeebe_adapter, first_active_job: Job):
-    zeebe_adapter.fail_job(job_key=first_active_job.key, message=str(uuid4()))
+    zeebe_adapter.fail_job(job_key=first_active_job.key, retries=first_active_job.retries, message=str(uuid4()))
     with pytest.raises(JobAlreadyDeactivatedError):
-        zeebe_adapter.fail_job(job_key=first_active_job.key, message=str(uuid4()))
+        zeebe_adapter.fail_job(job_key=first_active_job.key, retries=first_active_job.retries, message=str(uuid4()))
 
 
 def test_fail_job_common_errors_called(zeebe_adapter, first_active_job: Job):
@@ -127,7 +127,7 @@ def test_fail_job_common_errors_called(zeebe_adapter, first_active_job: Job):
 
     zeebe_adapter._gateway_stub.FailJob = MagicMock(side_effect=error)
 
-    zeebe_adapter.fail_job(job_key=first_active_job.key, message=str(uuid4()))
+    zeebe_adapter.fail_job(job_key=first_active_job.key, retries=first_active_job.retries, message=str(uuid4()))
 
     zeebe_adapter._common_zeebe_grpc_errors.assert_called()
 

--- a/tests/unit/job/job_test.py
+++ b/tests/unit/job/job_test.py
@@ -42,7 +42,7 @@ def test_failure(job_with_adapter):
     with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.fail_job") as fail_job_mock:
         message = str(uuid4())
         job_with_adapter.set_failure_status(message)
-        fail_job_mock.assert_called_with(job_key=job_with_adapter.key, message=message)
+        fail_job_mock.assert_called_with(job_key=job_with_adapter.key, retries=job_with_adapter.retries, message=message)
 
 
 def test_failure_no_zeebe_adapter(job_without_adapter):

--- a/tests/unit/job/job_test.py
+++ b/tests/unit/job/job_test.py
@@ -21,7 +21,15 @@ def test_error(job_with_adapter):
     with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.throw_error") as throw_error_mock:
         message = str(uuid4())
         job_with_adapter.set_error_status(message)
-        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message)
+        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code=None)
+
+
+def test_error_with_code(job_with_adapter):
+    with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.throw_error") as throw_error_mock:
+        message = str(uuid4())
+        error_code = "custom-error-code"
+        job_with_adapter.set_error_status(message, error_code)
+        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code=error_code)
 
 
 def test_error_no_zeebe_adapter(job_without_adapter):

--- a/tests/unit/job/job_test.py
+++ b/tests/unit/job/job_test.py
@@ -21,7 +21,7 @@ def test_error(job_with_adapter):
     with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.throw_error") as throw_error_mock:
         message = str(uuid4())
         job_with_adapter.set_error_status(message)
-        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code=None)
+        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code="")
 
 
 def test_error_with_code(job_with_adapter):
@@ -42,7 +42,7 @@ def test_failure(job_with_adapter):
     with patch("pyzeebe.grpc_internals.zeebe_adapter.ZeebeAdapter.fail_job") as fail_job_mock:
         message = str(uuid4())
         job_with_adapter.set_failure_status(message)
-        fail_job_mock.assert_called_with(job_key=job_with_adapter.key, retries=job_with_adapter.retries, message=message)
+        fail_job_mock.assert_called_with(job_key=job_with_adapter.key, retries=job_with_adapter.retries-1, message=message)
 
 
 def test_failure_no_zeebe_adapter(job_without_adapter):

--- a/tests/unit/worker/task_router_test.py
+++ b/tests/unit/worker/task_router_test.py
@@ -110,12 +110,17 @@ def test_default_exception_handler_logs_a_warning(mocked_job_with_adapter: Job):
         logging_mock.assert_called()
 
 
-def test_default_business_exception_handler(job_without_adapter):
+def test_default_exception_handler_uses_business_error(job_without_adapter):
+    with patch("pyzeebe.job.job.Job.set_error_status") as failure_mock:
+        error_code = "custom-error-code"
+        exception = BusinessError(error_code)
+        default_exception_handler(exception, job_without_adapter)
+        failure_mock.assert_called_with(mock.ANY, error_code=error_code)
+
+
+def test_default_exception_handler_warns_of_job_failure(job_without_adapter):
     with patch("pyzeebe.worker.task_router.logger.warning") as logging_mock:
-        with patch("pyzeebe.job.job.Job.set_error_status") as failure_mock:
-            failure_mock.return_value = None
-            error_code = "custom-error-code"
-            exception = BusinessError(error_code)
+        with patch("pyzeebe.job.job.Job.set_error_status"):
+            exception = BusinessError("custom-error-code")
             default_exception_handler(exception, job_without_adapter)
-            failure_mock.assert_called_with(mock.ANY, error_code=error_code)
         logging_mock.assert_called()


### PR DESCRIPTION
Add ability to specify an errorCode when throwing an error from a task, for later handling in Zeebe process. While working on that, I also noticed that the `retries` attribute of a `Job` object was never actually used and so a job was never set to be retried after a call to `set_failure_status`, I fixed that.

## Changes

- Fill `errorCode` argument when constructing a `ThrowErrorRequest`
- Fill `retries` argument when constructing a `FailJobRequest`

## API Updates

### New Features

- Add a `BusinessError` class with an `error_code` argument. This exception can be raised from a task to indicate that it failed with an anticipated  error handled in Zeebe process.

### Enhancements

- `Job.set_error_status` now accepts an `error_code` argument. Same goes for `ZeebeJobAdapter.throw_error`.
- `default_exception_handler` now calls `Job.set_error_status` when the exception is a `BusinessError`
- `ZeebeJobAdapter.fail_job` now accepts a retries argument. `Job.set_failure_status` pass the `Job.retries` to it.

## Checklist

- [X ] Unit tests
- [X ] Documentation

## References

Fixes #162
