### PR TITLE
`mypy` in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: Test pyzeebe
+
+on:
+  push:
+  pull_request:
+    branches: [ master, development ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    container: python:3.8
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          pip install pipenv
+          pipenv install --dev
+      - name: Lint with mypy
+        run: |
+          pipenv run mypy pyzeebe

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,17 @@
+[mypy]
+
+[mypy-grpc]
+ignore_missing_imports = True
+
+[mypy-oauthlib]
+ignore_missing_imports = True
+
+[mypy-requests_oauthlib]
+ignore_missing_imports = True
+
+[mypy-zeebe_grpc.gateway_pb2]
+ignore_missing_imports = True
+
+[mypy-zeebe_grpc.gateway_pb2_grpc]
+ignore_missing_imports = True
+

--- a/pyzeebe/credentials/oauth_credentials.py
+++ b/pyzeebe/credentials/oauth_credentials.py
@@ -37,4 +37,4 @@ class OAuthCredentials(BaseCredentials):
             raise InvalidOAuthCredentialsError(url=url, client_id=client_id, audience=audience)
 
     def get_connection_uri(self) -> str:
-        return None
+        return ""

--- a/pyzeebe/grpc_internals/zeebe_process_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_process_adapter.py
@@ -16,10 +16,10 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
             response = self._gateway_stub.CreateProcessInstance(
                 CreateProcessInstanceRequest(bpmnProcessId=bpmn_process_id, version=version,
                                              variables=json.dumps(variables)))
-            return response.processInstanceKey
         except grpc.RpcError as rpc_error:
             self._create_process_errors(
                 rpc_error, bpmn_process_id, version, variables)
+        return response.processInstanceKey
 
     def create_process_instance_with_result(self, bpmn_process_id: str, version: int, variables: Dict,
                                             timeout: int, variables_to_fetch) -> Tuple[int, Dict]:
@@ -29,10 +29,10 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
                     request=CreateProcessInstanceRequest(bpmnProcessId=bpmn_process_id, version=version,
                                                          variables=json.dumps(variables)),
                     requestTimeout=timeout, fetchVariables=variables_to_fetch))
-            return response.processInstanceKey, json.loads(response.variables)
         except grpc.RpcError as rpc_error:
             self._create_process_errors(
                 rpc_error, bpmn_process_id, version, variables)
+        return response.processInstanceKey, json.loads(response.variables)
 
     def _create_process_errors(self, rpc_error: grpc.RpcError, bpmn_process_id: str, version: int,
                                variables: Dict) -> None:

--- a/pyzeebe/worker/worker.py
+++ b/pyzeebe/worker/worker.py
@@ -124,7 +124,7 @@ class ZeebeWorker(ZeebeTaskRouter):
         return not self.stop_event.is_set() and bool(self._task_threads)
 
     def _watch_task_threads_runner(self, frequency: int = 10) -> None:
-        consecutive_errors = {}
+        consecutive_errors: Dict[str, int] = {}
         while self._should_watch_threads():
             logger.debug("Checking task thread status")
             # converting to list to avoid "RuntimeError: dictionary changed size during iteration"


### PR DESCRIPTION
Run `mypy` in GitHub Actions (on pushes and pull requests), and fix existing `mypy` errors

## Changes

- Refactoring: Add type hints

## API Updates

- `OAuthCredentials.get_connection_uri` incorrectly returned `None`, while the type annotation indicated `str`. It now returns correctly.

### New Features *(required)*

n/a

### Deprecations *(required)*

n/a

### Enhancements *(optional)*

n/a

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #148 