### PR TITLE
Wait for watcher to finish

### DIFF
--- a/pyzeebe/worker/worker.py
+++ b/pyzeebe/worker/worker.py
@@ -95,6 +95,8 @@ class ZeebeWorker(ZeebeTaskRouter):
         self.stop_event.set()
         if wait:
             self._join_task_threads()
+            if self._watcher_thread:
+                self._watcher_thread.join()
 
     def _join_task_threads(self) -> None:
         logger.debug("Waiting for threads to join")


### PR DESCRIPTION
In addition to waiting for task threads to join, wait for the watcher thread to finish when calling `worker.stop`. 

## Changes

- When calling `worker.stop(wait=True)` it will now also wait for the watcher thread to join before returning.

## API Updates

n/a

## Checklist

- [x] Unit tests
- [x] Documentation

Fixes #169