### PR TITLE
Change to run linting on all PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,6 @@
 name: Test pyzeebe
 
-on:
-  push:
-  pull_request:
-    branches: [ master, development ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Test pyzeebe
+name: Lint pyzeebe
 
 on: [push, pull_request]
 


### PR DESCRIPTION
This will ensure PRs aganst the `pre-release/3.0.0` branch (and others we may create in the future)  are linted. 

## References

Relates to #166 