### PR TITLE
Add access to job parameter inside task

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -2,7 +2,7 @@
 Errors
 ==========
 
-All ``pyzeebe`` exceptions inherit from :py:class:`PyZeebeError`
+All ``pyzeebe`` errors inherit from :py:class:`PyZeebeError`
 
 .. autoexception:: pyzeebe.errors.PyZeebeError
 

--- a/docs/worker_tasks.rst
+++ b/docs/worker_tasks.rst
@@ -132,3 +132,25 @@ This can be helpful when we don't want to read return values from a dictionary e
 
     The parameter ``variable_name`` must be supplied if ``single_value`` is true. If not given a :class:`NoVariableNameGiven` will be raised.
 
+Accessing the job object directly
+---------------------------------
+
+It is possible to receive the job object as a parameter inside a task function. Simply annotate the parameter with the :py:class:`pyzeebe.Job` type.
+
+Example:
+
+.. code-block:: python
+
+    from pyzeebe import Job
+
+
+    @worker.task(task_type="my_task")
+    async def my_task(job: Job):
+        print(job.process_instance_key)
+        return {**job.custom_headers}
+
+.. note::
+
+    Do not set the status for the job (set_success_status, set_failure_status or set_error_status) inside the task. 
+    This will cause pyzeebe to raise an :py:class:`pyzeebe.errors.ActivateJobsRequestInvalidError`.
+

--- a/pyzeebe/function_tools/parameter_tools.py
+++ b/pyzeebe/function_tools/parameter_tools.py
@@ -1,7 +1,8 @@
 import inspect
-from typing import List
+from typing import List, Optional
 
 from pyzeebe.function_tools import Function
+from pyzeebe.job.job import Job
 
 
 def get_parameters_from_function(task_function: Function) -> List[str]:
@@ -10,3 +11,12 @@ def get_parameters_from_function(task_function: Function) -> List[str]:
         if parameter.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
             return []
     return list(function_signature.parameters)
+
+
+def get_job_parameter_name(function: Function) -> Optional[str]:
+    function_signature = inspect.signature(function)
+    params = list(function_signature.parameters.values())
+    for param in params:
+        if param.annotation == Job:
+            return param.name
+    return None

--- a/pyzeebe/task/task_builder.py
+++ b/pyzeebe/task/task_builder.py
@@ -55,7 +55,7 @@ def prepare_task_function(task_function: Function, task_config: TaskConfig) -> D
 
 async def run_original_task_function(task_function: DictFunction, task_config: TaskConfig, job: Job) -> Tuple[Dict, bool]:
     try:
-        return await task_function(**job.variables), True
+        return await task_function(**job.variables), True  # type: ignore
     except Exception as e:
         logger.debug(f"Failed job: {job}. Error: {e}.")
         await task_config.exception_handler(e, job)

--- a/pyzeebe/task/task_config.py
+++ b/pyzeebe/task/task_config.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pyzeebe.errors import NoVariableNameGivenError
 from pyzeebe.function_tools import async_tools
@@ -27,6 +27,7 @@ class TaskConfig:
         self.variable_name = variable_name
         self.before = async_tools.asyncify_all_functions(before)
         self.after = async_tools.asyncify_all_functions(after)
+        self.job_parameter_name: Optional[str] = None
 
     def __repr__(self):
         return f"TaskConfig(type={self.type}, exception_handler={self.exception_handler}, " \

--- a/tests/unit/function_tools/parameter_tools_test.py
+++ b/tests/unit/function_tools/parameter_tools_test.py
@@ -3,6 +3,7 @@ from typing import Callable, List
 import pytest
 
 from pyzeebe.function_tools import parameter_tools
+from pyzeebe.job.job import Job
 from tests.unit.utils import dummy_functions
 
 
@@ -26,3 +27,23 @@ class TestGetFunctionParameters:
     ])
     def test_get_params(self, fn: Callable, expected: List[str]):
         assert parameter_tools.get_parameters_from_function(fn) == expected
+
+
+class TestGetJobParameter:
+    def test_returns_none_when_there_are_no_parameters_annotated_with_job(self):
+        job_parameter = parameter_tools.get_job_parameter_name(
+            dummy_functions.multiple_params)
+
+        assert job_parameter == None
+
+    def test_returns_parameter_name_when_annotated(self):
+        job_parameter = parameter_tools.get_job_parameter_name(
+            dummy_functions.with_job_parameter)
+
+        assert job_parameter == "job"
+
+    def test_returns_first_parameter_annotated_with_job(self):
+        job_parameter = parameter_tools.get_job_parameter_name(
+            dummy_functions.with_multiple_job_parameters)
+
+        assert job_parameter == "job"

--- a/tests/unit/task/task_builder_test.py
+++ b/tests/unit/task/task_builder_test.py
@@ -38,6 +38,17 @@ class TestBuildTask:
         assert len(job.variables.keys()) == 1
         assert set(job.variables.keys()) == {"y"}
 
+    @pytest.mark.asyncio
+    async def test_job_parameter_is_injected_in_task(self, task_config: TaskConfig, mocked_job_with_adapter: Job):
+        def function_with_job_parameter(job: Job):
+            return {"job": job}
+
+        task = task_builder.build_task(
+            function_with_job_parameter, task_config)
+        job = await task.job_handler(mocked_job_with_adapter)
+
+        assert job.variables["job"] == mocked_job_with_adapter
+
 
 class TestBuildJobHandler:
     def test_returned_task_is_callable(self, original_task_function: Callable, task_config: TaskConfig):
@@ -153,3 +164,17 @@ class TestBuildJobHandler:
         job = await job_handler(mocked_job_with_adapter)
 
         assert "x" in job.variables
+
+    @pytest.mark.asyncio
+    async def test_job_parameter_is_injected(self, task_config: TaskConfig, mocked_job_with_adapter: Job):
+        def function_with_job_parameter(x: int, job: Job):
+            return {"job": job}
+
+        task_config.job_parameter_name = "job"
+
+        job_handler = task_builder.build_job_handler(
+            function_with_job_parameter, task_config
+        )
+        job = await job_handler(mocked_job_with_adapter)
+
+        assert job.variables["job"] == mocked_job_with_adapter

--- a/tests/unit/utils/dummy_functions.py
+++ b/tests/unit/utils/dummy_functions.py
@@ -1,3 +1,6 @@
+from pyzeebe.job.job import Job
+
+
 def no_param():
     pass
 
@@ -34,9 +37,17 @@ def standard_named_params(args, kwargs):
     pass
 
 
-lambda_no_params = lambda: None
-lambda_one_param = lambda x: None
-lambda_multiple_params = lambda x, y, z: None
-lambda_one_keyword_param = lambda x=0: None
-lambda_multiple_keyword_params = lambda x=0, y=0, z=0: None
-lambda_positional_and_keyword_params = lambda x, y=0: None
+def with_job_parameter(job: Job):
+    pass
+
+
+def with_multiple_job_parameters(job: Job, job2: Job):
+    pass
+
+
+def lambda_no_params(): return None
+def lambda_one_param(x): return None
+def lambda_multiple_params(x, y, z): return None
+def lambda_one_keyword_param(x=0): return None
+def lambda_multiple_keyword_params(x=0, y=0, z=0): return None
+def lambda_positional_and_keyword_params(x, y=0): return None


### PR DESCRIPTION
Add ability to access the job instance from inside a task.

## Changes

- If type annotated with `pyzeebe.Job`, the job instance will be injected into the task

## API Updates

### New Features 

- If a parameter of a task function is annotated with the `pyzeebe.Job` type, pyzeebe will inject the object into the task

### Deprecations

none

### Enhancements

none

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Solves #100, #161