### PR TITLE
Configure gRPC channel (port from 2.3.2 to 3.0.0)

### DIFF
--- a/pyzeebe/grpc_internals/channel_options.py
+++ b/pyzeebe/grpc_internals/channel_options.py
@@ -1,0 +1,15 @@
+GRPC_CHANNEL_OPTIONS = {
+    # https://docs.camunda.io/docs/product-manuals/zeebe/deployment-guide/operations/setting-up-a-cluster/#keep-alive-intervals
+    # "By default, the official Zeebe clients (Java and Go) send keep alive pings every 45 seconds."
+    "grpc.keepalive_time_ms": 45_000
+}
+
+
+def get_channel_options():
+    """
+    Channel arguments are expected as a tuple of tuples:
+    https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
+    """
+    return tuple(
+        (k, v) for k, v in GRPC_CHANNEL_OPTIONS.items()
+    )

--- a/pyzeebe/grpc_internals/channel_options.py
+++ b/pyzeebe/grpc_internals/channel_options.py
@@ -7,7 +7,7 @@ Time between keepalive pings. Following the official Zeebe Java/Go client, sendi
 
 https://docs.camunda.io/docs/product-manuals/zeebe/deployment-guide/operations/setting-up-a-cluster/#keep-alive-intervals
 """
-from typing import Dict, Any, Tuple
+from typing import Any, Dict, Tuple
 
 GRPC_CHANNEL_OPTIONS = {
     "grpc.keepalive_time_ms": 45_000

--- a/pyzeebe/grpc_internals/channel_options.py
+++ b/pyzeebe/grpc_internals/channel_options.py
@@ -1,15 +1,37 @@
+""" gRPC Channel Options
+
+``grpc.keepalive_time_ms``
+--------------------------
+
+Time between keepalive pings. Following the official Zeebe Java/Go client, sending pings every 45 seconds.
+
+https://docs.camunda.io/docs/product-manuals/zeebe/deployment-guide/operations/setting-up-a-cluster/#keep-alive-intervals
+"""
+from typing import Dict, Any, Tuple
+
 GRPC_CHANNEL_OPTIONS = {
-    # https://docs.camunda.io/docs/product-manuals/zeebe/deployment-guide/operations/setting-up-a-cluster/#keep-alive-intervals
-    # "By default, the official Zeebe clients (Java and Go) send keep alive pings every 45 seconds."
     "grpc.keepalive_time_ms": 45_000
 }
 
 
-def get_channel_options():
+def get_channel_options(options: Dict[str, Any] = None) -> Tuple[Tuple[str, Any], ...]:
     """
-    Channel arguments are expected as a tuple of tuples:
-    https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
+    Convert options dict to tuple in expected format for creating the gRPC channel
+
+    Args:
+        options (Dict[str, Any]): A key/value representation of `gRPC channel arguments_`.
+            Default: None (will use library defaults)
+
+    Returns:
+        Tuple[Tuple[str, Any], ...]: Options for the gRPC channel
+
+    .. _gRPC channel arguments:
+        https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
     """
+    if options:
+        options = {**GRPC_CHANNEL_OPTIONS, **options}
+    else:
+        options = GRPC_CHANNEL_OPTIONS
     return tuple(
-        (k, v) for k, v in GRPC_CHANNEL_OPTIONS.items()
+        (k, v) for k, v in options.items()
     )

--- a/pyzeebe/grpc_internals/grpc_channel_utils.py
+++ b/pyzeebe/grpc_internals/grpc_channel_utils.py
@@ -1,10 +1,11 @@
 import os
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 import grpc
 
 from pyzeebe.credentials.base_credentials import BaseCredentials
 from pyzeebe.grpc_internals.channel_options import get_channel_options
+
 
 def create_connection_uri(
     hostname: str = None,

--- a/pyzeebe/grpc_internals/grpc_channel_utils.py
+++ b/pyzeebe/grpc_internals/grpc_channel_utils.py
@@ -4,7 +4,7 @@ from typing import Optional
 import grpc
 
 from pyzeebe.credentials.base_credentials import BaseCredentials
-
+from pyzeebe.grpc_internals.channel_options import get_channel_options
 
 def create_connection_uri(
     hostname: str = None,
@@ -23,8 +23,9 @@ def create_channel(
     credentials: Optional[BaseCredentials] = None,
     secure_connection: bool = False
 ) -> grpc.aio.Channel:
+    options = get_channel_options()
     if credentials:
-        return grpc.aio.secure_channel(connection_uri, credentials.grpc_credentials)
+        return grpc.aio.secure_channel(connection_uri, credentials.grpc_credentials, options=options)
     if secure_connection:
-        return grpc.aio.secure_channel(connection_uri, grpc.ssl_channel_credentials())
-    return grpc.aio.insecure_channel(connection_uri)
+        return grpc.aio.secure_channel(connection_uri, grpc.ssl_channel_credentials(), options=options)
+    return grpc.aio.insecure_channel(connection_uri, options=options)

--- a/pyzeebe/grpc_internals/grpc_channel_utils.py
+++ b/pyzeebe/grpc_internals/grpc_channel_utils.py
@@ -26,16 +26,7 @@ def create_channel(
     options: Dict[str, Any] = None
 ) -> grpc.aio.Channel:
     """
-    Create a gRPC channel.
-
-    Args:
-        connection_uri (str): The URI to Zeebe.
-        credentials (BaseCredentials): Credentials for accessing the channel. Default: None
-        secure_connection (bool): Create a secure channel (set to True when using credentials). Default: False
-        options (Dict[str, Any]): A key/value representation of `gRPC channel arguments_`. Default: None (will use library defaults)
-
-    Returns:
-        grpc.aio.Channel: A channel object set up to connect to Zeebe
+    options: A key/value representation of `gRPC channel arguments_`. Default: None (will use library defaults)
 
     .. _gRPC channel arguments:
         https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments

--- a/pyzeebe/grpc_internals/grpc_channel_utils.py
+++ b/pyzeebe/grpc_internals/grpc_channel_utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Optional, Dict, Any
 
 import grpc
 
@@ -21,11 +21,27 @@ def create_connection_uri(
 def create_channel(
     connection_uri: str,
     credentials: Optional[BaseCredentials] = None,
-    secure_connection: bool = False
+    secure_connection: bool = False,
+    options: Dict[str, Any] = None
 ) -> grpc.aio.Channel:
-    options = get_channel_options()
+    """
+    Create a gRPC channel.
+
+    Args:
+        connection_uri (str): The URI to Zeebe.
+        credentials (BaseCredentials): Credentials for accessing the channel. Default: None
+        secure_connection (bool): Create a secure channel (set to True when using credentials). Default: False
+        options (Dict[str, Any]): A key/value representation of `gRPC channel arguments_`. Default: None (will use library defaults)
+
+    Returns:
+        grpc.aio.Channel: A channel object set up to connect to Zeebe
+
+    .. _gRPC channel arguments:
+        https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
+    """
+    channel_options = get_channel_options(options)
     if credentials:
-        return grpc.aio.secure_channel(connection_uri, credentials.grpc_credentials, options=options)
+        return grpc.aio.secure_channel(connection_uri, credentials.grpc_credentials, options=channel_options)
     if secure_connection:
-        return grpc.aio.secure_channel(connection_uri, grpc.ssl_channel_credentials(), options=options)
-    return grpc.aio.insecure_channel(connection_uri, options=options)
+        return grpc.aio.secure_channel(connection_uri, grpc.ssl_channel_credentials(), options=channel_options)
+    return grpc.aio.insecure_channel(connection_uri, options=channel_options)

--- a/tests/unit/grpc_internals/channel_options_test.py
+++ b/tests/unit/grpc_internals/channel_options_test.py
@@ -1,0 +1,70 @@
+from copy import deepcopy
+
+import pytest
+from unittest.mock import patch, Mock
+
+from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
+
+import pyzeebe.grpc_internals.channel_options
+from pyzeebe.grpc_internals.channel_options import get_channel_options
+
+
+@pytest.fixture
+def revert_monkeypatch_after_test():
+    """
+    This sort of exists in pytest already (docs.pytest.org/en/stable/monkeypatch.html),
+    however that means a bit of "magic" happens, this is a bit clearer and tests the users
+    approach to this.
+    """
+    options_before = deepcopy(pyzeebe.grpc_internals.channel_options.GRPC_CHANNEL_OPTIONS)
+    yield
+    pyzeebe.grpc_internals.channel_options.GRPC_CHANNEL_OPTIONS = options_before
+
+
+def test_get_channel_options_returns_tuple_of_tuple_with_options():
+    assert get_channel_options() == (
+        ("grpc.keepalive_time_ms", 45000),
+    )
+
+
+@pytest.mark.parametrize("grpc_method,call_kwargs",
+                         [
+                             ("grpc.aio.secure_channel", {"secure_connection": True}),
+                             ("grpc.aio.insecure_channel", {}),
+                             ("grpc.aio.secure_channel", {"credentials": Mock()}),
+                         ])
+def test_create_channel_called_with_options(grpc_method, call_kwargs, zeebe_adapter):
+    with patch(grpc_method) as channel_mock:
+        ZeebeAdapterBase(**call_kwargs).connect()
+        expected_options = (('grpc.keepalive_time_ms', 45000),)
+        # `call_args.kwargs` as it's not available in python <=3.7
+        # https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.call_args
+        # 0 is args, 1 is kwargs
+        assert channel_mock.call_args[1]["options"] == expected_options
+
+
+@pytest.mark.usefixtures("revert_monkeypatch_after_test")
+def test_monkeypatching_with_options_override():
+    pyzeebe.grpc_internals.channel_options.GRPC_CHANNEL_OPTIONS["grpc.keepalive_time_ms"] = 4000
+    assert get_channel_options() == (
+        ("grpc.keepalive_time_ms", 4000),
+    )
+
+
+@pytest.mark.usefixtures("revert_monkeypatch_after_test")
+def test_monkeypatching_with_options_added():
+    pyzeebe.grpc_internals.channel_options.GRPC_CHANNEL_OPTIONS.update({
+        "grpc.keepalive_timeout_ms": 120000,
+        "grpc.http2.min_time_between_pings_ms": 60000,
+    })
+    assert get_channel_options() == (
+        ("grpc.keepalive_time_ms", 45000),
+        ("grpc.keepalive_timeout_ms", 120000),
+        ("grpc.http2.min_time_between_pings_ms", 60000)
+    )
+
+
+@pytest.mark.usefixtures("revert_monkeypatch_after_test")
+def test_monkeypatching_with_options_removed():
+    pyzeebe.grpc_internals.channel_options.GRPC_CHANNEL_OPTIONS = {}
+    assert get_channel_options() == ()

--- a/tests/unit/grpc_internals/channel_options_test.py
+++ b/tests/unit/grpc_internals/channel_options_test.py
@@ -1,12 +1,11 @@
 from copy import deepcopy
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import patch, Mock
-
-from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 
 import pyzeebe.grpc_internals.channel_options
 from pyzeebe.grpc_internals.channel_options import get_channel_options
+from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 
 
 @pytest.fixture

--- a/tests/unit/grpc_internals/grpc_channel_utils_test.py
+++ b/tests/unit/grpc_internals/grpc_channel_utils_test.py
@@ -26,6 +26,29 @@ class TestCreateChannel:
 
             channel_mock.assert_called_once()
 
+    def test_creates_secure_channel_with_default_options(self):
+        with patch("grpc.aio.insecure_channel") as channel_mock:
+            create_channel(str(uuid4()), options=None)
+
+            expected_options = (
+                ("grpc.keepalive_time_ms", 45000),
+            )
+            assert channel_mock.call_args[1]["options"] == expected_options
+
+    def test_creates_insecure_channel_with_options(self):
+        with patch("grpc.aio.insecure_channel") as channel_mock:
+            additional_options = {
+                "grpc.keepalive_timeout_ms": 120000,
+                "grpc.http2.min_time_between_pings_ms": 60000,
+            }
+            create_channel(str(uuid4()), options=additional_options)
+
+            expected_options = (
+                ("grpc.keepalive_time_ms", 45000),
+                ("grpc.keepalive_timeout_ms", 120000),
+                ("grpc.http2.min_time_between_pings_ms", 60000),
+            )
+            assert channel_mock.call_args[1]["options"] == expected_options
 
 class TestCreateConnectionUri:
     def test_uses_credentials_first(self):


### PR DESCRIPTION
_Port of #180 (e43945c). With some additions_

Configure gRPC channel with shorter time between keep-alive pings (from 2 hours to 45 sec).

This ensures that ZeebeClient and ZeebeWorker detects if the gateway has become unavailable (e.g. due to network issues).

## Changes

- When setting up the channel, include `grpc.keepalive_time_ms`, set to 45000 (45 sec) – the same default as the official Zeebe clients ([docs](https://docs.camunda.io/docs/0.25/product-manuals/zeebe/operations/setting-up-a-cluster/#keep-alive-intervals)) 

## API Updates

### New Features *(required)*

`pyzeebe.grpc_internals.channel_options.GRPC_CHANNEL_OPTIONS` is a dict added - while this is not part of the official API, it _can_ still be monkeypatched, if the values need to be changed. 

### Deprecations *(required)*

n/a

### Enhancements *(optional)*

n/a

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #178
See also #180 
