### PR TITLE
Raise ProcessTimeoutError when timeout is reached

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -28,6 +28,8 @@ All ``pyzeebe`` errors inherit from :py:class:`PyZeebeError`
 
 .. autoexception:: pyzeebe.errors.ProcessDefinitionHasNoStartEventError
 
+.. autoexception:: pyzeebe.errors.ProcessTimeoutError
+
 .. autoexception:: pyzeebe.errors.ProcessInvalidError
 
 .. autoexception:: pyzeebe.errors.InvalidJSONError

--- a/pyzeebe/client/client.py
+++ b/pyzeebe/client/client.py
@@ -71,6 +71,7 @@ class ZeebeClient(object):
             ProcessDefinitionNotFoundError: No process with bpmn_process_id exists
             InvalidJSONError: variables is not JSONable
             ProcessDefinitionHasNoStartEventError: The specified process does not have a start event
+            ProcessTimeoutError: The process was not finished within the set timeout
             ZeebeBackPressureError: If Zeebe is currently in back pressure (too many requests)
             ZeebeGatewayUnavailableError: If the Zeebe gateway is unavailable
             ZeebeInternalError: If Zeebe experiences an internal error

--- a/pyzeebe/errors/process_errors.py
+++ b/pyzeebe/errors/process_errors.py
@@ -4,22 +4,23 @@ from pyzeebe.errors.pyzeebe_errors import PyZeebeError
 class ProcessDefinitionNotFoundError(PyZeebeError):
     def __init__(self, bpmn_process_id: str, version: int):
         super().__init__(
-            f"Process definition: {bpmn_process_id}  with {version} was not found")
+            f"Process definition: {bpmn_process_id}  with {version} was not found"
+        )
         self.bpmn_process_id = bpmn_process_id
         self.version = version
 
 
 class ProcessInstanceNotFoundError(PyZeebeError):
     def __init__(self, process_instance_key: int):
-        super().__init__(
-            f"Process instance key: {process_instance_key} was not found")
+        super().__init__(f"Process instance key: {process_instance_key} was not found")
         self.process_instance_key = process_instance_key
 
 
 class ProcessDefinitionHasNoStartEventError(PyZeebeError):
     def __init__(self, bpmn_process_id: str):
         super().__init__(
-            f"Process {bpmn_process_id} has no start event that can be called manually")
+            f"Process {bpmn_process_id} has no start event that can be called manually"
+        )
         self.bpmn_process_id = bpmn_process_id
 
 
@@ -33,5 +34,7 @@ class InvalidJSONError(PyZeebeError):
 
 class ProcessTimeoutError(PyZeebeError, TimeoutError):
     def __init__(self, bpmn_process_id: str):
-        super().__init__(f"Timeout while waiting for {bpmn_process_id} to complete")
+        super().__init__(
+            f"Timeout while waiting for process {bpmn_process_id} to complete"
+        )
         self.bpmn_process_id = bpmn_process_id

--- a/pyzeebe/errors/process_errors.py
+++ b/pyzeebe/errors/process_errors.py
@@ -29,3 +29,9 @@ class ProcessInvalidError(PyZeebeError):
 
 class InvalidJSONError(PyZeebeError):
     pass
+
+
+class ProcessTimeoutError(PyZeebeError, TimeoutError):
+    def __init__(self, bpmn_process_id: str):
+        super().__init__(f"Timeout while waiting for {bpmn_process_id} to complete")
+        self.bpmn_process_id = bpmn_process_id


### PR DESCRIPTION
Raise `ProcessTimeoutError` when timeout is reached when waiting for process result.

## Changes

- Raise `ProcessTimeoutError` when process takes too long to complete

## API Updates

### New Features

none

### Deprecations

none

## Checklist

- [x] Unit tests
- [x] Documentation

