### PR TITLE
add support for Camunda Cloud 1.1

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -60,7 +60,7 @@ To create a client for a Camunda Cloud instance:
 
     credentials = CamundaCloudCredentials(client_id="client_id", client_secret="client_secret",
                                           cluster_id="cluster_id")
-    client = ZeebeClient()
+    client = ZeebeClient(credentials=credentials)
 
 
 Run a workflow

--- a/docs/worker_quickstart.rst
+++ b/docs/worker_quickstart.rst
@@ -74,7 +74,7 @@ To create a worker for a Camunda Cloud instance:
 
     credentials = CamundaCloudCredentials(client_id="client_id", client_secret="client_secret",
                                           cluster_id="cluster_id")
-    worker = ZeebeWorker()
+    worker = ZeebeWorker(credentials=credentials)
 
 
 Add a task

--- a/pyzeebe/credentials/camunda_cloud_credentials.py
+++ b/pyzeebe/credentials/camunda_cloud_credentials.py
@@ -3,10 +3,10 @@ from pyzeebe.exceptions import InvalidOAuthCredentials, InvalidCamundaCloudCrede
 
 
 class CamundaCloudCredentials(OAuthCredentials):
-    def __init__(self, client_id: str, client_secret: str, cluster_id: str):
+    def __init__(self, client_id: str, client_secret: str, cluster_id: str, region: str="bru-2"):
         try:
             super().__init__(url="https://login.cloud.camunda.io/oauth/token", client_id=client_id,
-                             client_secret=client_secret, audience=f"{cluster_id}.zeebe.camunda.io")
+                             client_secret=client_secret, audience=f"{cluster_id}.{region}.zeebe.camunda.io")
         except InvalidOAuthCredentials:
             raise InvalidCamundaCloudCredentials(client_id=client_id, cluster_id=cluster_id)
 

--- a/tests/unit/credentials/camunda_cloud_credentials_test.py
+++ b/tests/unit/credentials/camunda_cloud_credentials_test.py
@@ -15,7 +15,7 @@ def test_init():
     with patch("pyzeebe.credentials.oauth_credentials.OAuthCredentials.__init__") as init:
         CamundaCloudCredentials(client_id, client_secret, cluster_id)
         init.assert_called_with(url=f"https://login.cloud.camunda.io/oauth/token", client_id=client_id,
-                                client_secret=client_secret, audience=f"{cluster_id}.zeebe.camunda.io")
+                                client_secret=client_secret, audience=f"{cluster_id}.bru-2.zeebe.camunda.io")
 
 
 def test_invalid_credentials():

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -116,7 +116,7 @@ def test_credentials_connection_uri_gotten(zeebe_adapter):
     CamundaCloudCredentials.get_access_token = MagicMock(return_value=str(uuid4()))
     credentials = CamundaCloudCredentials(client_id, client_secret, cluster_id)
     zeebe_adapter = ZeebeAdapterBase(credentials=credentials)
-    assert zeebe_adapter.connection_uri == f"{cluster_id}.zeebe.camunda.io:443"
+    assert zeebe_adapter.connection_uri == f"{cluster_id}.bru-2.zeebe.camunda.io:443"
 
 
 def test_credentials_no_connection_uri(zeebe_adapter):


### PR DESCRIPTION
Camunda Cloud 1.1 adds multi regions support. So a region can be defined in the credentials and should default to bru-2

Changes
Camunda Cloud credentials takes an optional region parameter if no value is supplied it uses the default bru-2
API Updates
New Features (required)
Camunda Cloud credentials takes an optional region parameter if no value is supplied it uses the default bru-2

Checklist
[ x] Unit tests
[x ] Documentation

References

Notes: Couldn't get the tests to run
This PR is against development and deprecates #204 