### PR TITLE
Add support for camunda cloud regions

### DIFF
--- a/examples/client.py
+++ b/examples/client.py
@@ -14,6 +14,7 @@ grpc_channel = create_camunda_cloud_channel(
     client_id="<my_client_id>",
     client_secret="<my_client_secret>",
     cluster_id="<my_cluster_id>",
+    region="<region>" # Default is bru-2
 )
 zeebe_client = ZeebeClient(grpc_channel)
 

--- a/examples/worker.py
+++ b/examples/worker.py
@@ -35,6 +35,7 @@ grpc_channel = create_camunda_cloud_channel(
     client_id="<my_client_id>",
     client_secret="<my_client_secret>",
     cluster_id="<my_cluster_id>",
+    region="<region>" # Default value is bru-2
 )
 worker = ZeebeWorker(grpc_channel)
 

--- a/pyzeebe/channel/camunda_cloud_channel.py
+++ b/pyzeebe/channel/camunda_cloud_channel.py
@@ -14,6 +14,7 @@ def create_camunda_cloud_channel(
     client_id: str,
     client_secret: str,
     cluster_id: str,
+    region: str = "bru-2",
     channel_options: Optional[Dict] = None,
 ) -> grpc.aio.Channel:
     """
@@ -23,6 +24,7 @@ def create_camunda_cloud_channel(
         client_id (str): The client id provided by Camunda Cloud
         client_secret (str): The client secret provided by Camunda Cloud
         cluster_id (str): The zeebe cluster id to connect to
+        region (str): The cluster's region. Defaults to bru-2
         channel_options (Optional[Dict], optional): GRPC channel options. See https://grpc.github.io/grpc/python/glossary.html
 
     Returns:
@@ -36,7 +38,7 @@ def create_camunda_cloud_channel(
     )
 
     return grpc.aio.secure_channel(
-        f"{cluster_id}.zeebe.camunda.io:443",
+        f"{cluster_id}.{region}.zeebe.camunda.io:443",
         channel_credentials,
         options=get_channel_options(channel_options),
     )


### PR DESCRIPTION
Add support to camunda cloud regions. See #208 for pyzeebe 2.x.x support.

## Changes

- Add a new parameter called `region` to `create_camunda_cloud_channel`. Defaults to bru-2

## API Updates

### New Features

- Add ability to specify the region of the camunda cloud zeebe cluster

## Checklist

- [x] Unit tests
- [x] Documentation
