### PR TITLE
Change docs from using asyncio.run to loop.run_until_complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ def example_task(input: str) -> dict:
 async def another_example_task(name: str) -> dict: # Tasks can also be async
     return {"output": f"Hello world, {name} from async task!"}
 
-asyncio.run(worker.work()) # Now every time that a task with type `example` or `example2` is called, the corresponding function will be called
+loop = asyncio.get_running_loop()
+loop.run_until_complete(worker.work()) # Now every time that a task with type `example` or `example2` is called, the corresponding function will be called
 ```
 
 Stop a worker:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,7 +36,8 @@ release = '3.0.0rc3'
 extensions = [
     "sphinx_rtd_theme",
     "sphinx.ext.autodoc",
-    "sphinx.ext.napoleon"
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autosectionlabel"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/worker_quickstart.rst
+++ b/docs/worker_quickstart.rst
@@ -5,6 +5,8 @@ Worker Quickstart
 Create and start a worker
 -------------------------
 
+Run using event loop
+
 .. code-block:: python
 
     import asyncio
@@ -19,7 +21,25 @@ Create and start a worker
     async def my_task(x: int):
         return {"y": x + 1}
 
-    asyncio.run(worker.work())
+    loop = asyncio.get_running_loop()
+    loop.run_until_complete(worker.work())
+
+.. warning::
+
+   Calling ``worker.work`` directly using ``asyncio.run`` will not work. When you create an async grpc channel a new event loop will automatically be created, which causes problems when running the worker (see: https://github.com/camunda-community-hub/pyzeebe/issues/198).
+   
+   An easy workaround:
+
+    .. code-block:: python
+    
+        async def main():
+            channel = create_insecure_channel()
+            worker = ZeebeWorker(channel)
+            await worker.work()
+
+        asyncio.run(main())
+
+    This does make it somewhat harder to add tasks to a worker. The recommended way to deal with this is using a :ref:`Task Router`.
 
 
 Worker connection options

--- a/examples/worker.py
+++ b/examples/worker.py
@@ -97,4 +97,5 @@ async def decorator_task() -> Dict:
 
 
 if __name__ == "__main__":
-    asyncio.run(worker.work())
+    loop = asyncio.get_running_loop()
+    loop.run_until_complete(worker.work())


### PR DESCRIPTION
Change docs to use a workaround.

## Changes

- Use `loop.run_until_complete` instead of `asyncio.run` in docs.
- Add warning to worker quickstart with an explanation and link to #198 

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #198 
