### PR TITLE
Fix: 212 job reactivation crashes worker

### DIFF
--- a/pyzeebe/worker/task_state.py
+++ b/pyzeebe/worker/task_state.py
@@ -7,19 +7,18 @@ logger = logging.getLogger(__name__)
 
 class TaskState:
     def __init__(self):
-        self._active_jobs = set()
+        self._active_jobs = list()
 
     def remove(self, job: Job) -> None:
         try:
             self._active_jobs.remove(job.key)
-        except KeyError:
+        except ValueError:
             logger.warning(
-                f"Could not find Job key {job.key} when trying to remove from TaskState")
+                f"Could not find Job key {job.key} when trying to remove from TaskState"
+            )
 
     def add(self, job: Job) -> None:
-        if job.key in self._active_jobs:
-            raise ValueError(f"Job {job.key} already registered in TaskState")
-        self._active_jobs.add(job.key)
+        self._active_jobs.append(job.key)
 
     def count_active(self) -> int:
         return len(self._active_jobs)

--- a/tests/unit/worker/task_state_test.py
+++ b/tests/unit/worker/task_state_test.py
@@ -1,5 +1,4 @@
 import pytest
-
 from pyzeebe.job.job import Job
 from pyzeebe.worker.task_state import TaskState
 
@@ -9,23 +8,23 @@ def task_state():
     return TaskState()
 
 
-def test_new_task_state_has_0_active_jobs(task_state):
+def test_new_task_state_has_0_active_jobs(task_state: TaskState):
     assert task_state.count_active() == 0
 
 
-def test_add_counts_as_active(task_state, job_from_task):
+def test_add_counts_as_active(task_state: TaskState, job_from_task):
     task_state.add(job_from_task)
     assert task_state.count_active() == 1
 
 
-def test_add_then_remove_results_in_0_active(task_state, job_from_task):
+def test_add_then_remove_results_in_0_active(task_state: TaskState, job_from_task: Job):
     task_state.add(job_from_task)
     task_state.remove(job_from_task)
     assert task_state.count_active() == 0
 
 
 def test_remove_non_existing_job_dont_withdraw_from_active_jobs(
-    task_state, job_from_task
+    task_state: TaskState, job_from_task: Job
 ):
     task_state.remove(job_from_task)
     assert task_state.count_active() == 0

--- a/tests/unit/worker/task_state_test.py
+++ b/tests/unit/worker/task_state_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pyzeebe.job.job import Job
 from pyzeebe.worker.task_state import TaskState
 
 
@@ -23,13 +24,15 @@ def test_add_then_remove_results_in_0_active(task_state, job_from_task):
     assert task_state.count_active() == 0
 
 
-def test_prevents_adding_duplicate_job(task_state, job_from_task):
-    with pytest.raises(ValueError) as exc_info:
-        for _ in range(2):
-            task_state.add(job_from_task)
-    assert exc_info.value.args[0].endswith("already registered in TaskState")
-
-
-def test_remove_non_existing_job_dont_withdraw_from_active_jobs(task_state, job_from_task):
+def test_remove_non_existing_job_dont_withdraw_from_active_jobs(
+    task_state, job_from_task
+):
     task_state.remove(job_from_task)
     assert task_state.count_active() == 0
+
+
+def test_add_already_activated_job_does_not_raise_an_error(
+    task_state: TaskState, job_from_task: Job
+):
+    task_state.add(job_from_task)
+    task_state.add(job_from_task)

--- a/tests/unit/worker/task_state_test.py
+++ b/tests/unit/worker/task_state_test.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyzeebe.job.job import Job
 from pyzeebe.worker.task_state import TaskState
 


### PR DESCRIPTION
Fix issue where the worker would stop after receiving a reactivated job. See #212 

## Changes

- Change `TaskState` to allow multiple jobs with the same key

## API Updates

### New Features
none

### Deprecations
none

### Enhancements 

- Add type hinting to unit tests of task state

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #212