### PR TITLE
Fix: Catch cancelled error status from gateway

### DIFF
--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -20,45 +20,47 @@ def test_should_retry_current_retries_over_max(zeebe_adapter: ZeebeAdapterBase):
 
 @pytest.mark.asyncio
 async def test_common_zeebe_grpc_error_internal(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(
-        grpc.StatusCode.INTERNAL, None, None
-    )
+    error = grpc.aio.AioRpcError(grpc.StatusCode.INTERNAL, None, None)
     with pytest.raises(ZeebeInternalError):
         await zeebe_adapter._common_zeebe_grpc_errors(error)
 
 
 @pytest.mark.asyncio
 async def test_common_zeebe_grpc_error_back_pressure(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(
-        grpc.StatusCode.RESOURCE_EXHAUSTED, None, None
-    )
+    error = grpc.aio.AioRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED, None, None)
     with pytest.raises(ZeebeBackPressureError):
         await zeebe_adapter._common_zeebe_grpc_errors(error)
 
 
 @pytest.mark.asyncio
-async def test_common_zeebe_grpc_error_gateway_unavailable(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(
-        grpc.StatusCode.UNAVAILABLE, None, None
-    )
+async def test_common_zeebe_grpc_error_gateway_unavailable(
+    zeebe_adapter: ZeebeAdapterBase,
+):
+    error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
+    with pytest.raises(ZeebeGatewayUnavailableError):
+        await zeebe_adapter._common_zeebe_grpc_errors(error)
+
+
+@pytest.mark.asyncio
+async def test_common_zeebe_grpc_errors_raises_gateway_unavailable_on_cancelled(
+    zeebe_adapter: ZeebeAdapterBase,
+):
+    error = grpc.aio.AioRpcError(grpc.StatusCode.CANCELLED, None, None)
+
     with pytest.raises(ZeebeGatewayUnavailableError):
         await zeebe_adapter._common_zeebe_grpc_errors(error)
 
 
 @pytest.mark.asyncio
 async def test_common_zeebe_grpc_error_unkown_error(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(
-        "FakeGrpcStatus", None, None
-    )
+    error = grpc.aio.AioRpcError("FakeGrpcStatus", None, None)
     with pytest.raises(grpc.aio.AioRpcError):
         await zeebe_adapter._common_zeebe_grpc_errors(error)
 
 
 @pytest.mark.asyncio
 async def test_close_after_retried_unavailable(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(
-        grpc.StatusCode.UNAVAILABLE, None, None
-    )
+    error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
 
     zeebe_adapter._close = AsyncMock()
     zeebe_adapter._max_connection_retries = 1
@@ -70,9 +72,7 @@ async def test_close_after_retried_unavailable(zeebe_adapter: ZeebeAdapterBase):
 
 @pytest.mark.asyncio
 async def test_close_after_retried_internal(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(
-        grpc.StatusCode.INTERNAL, None, None
-    )
+    error = grpc.aio.AioRpcError(grpc.StatusCode.INTERNAL, None, None)
     zeebe_adapter._close = AsyncMock()
     zeebe_adapter._max_connection_retries = 1
     with pytest.raises(ZeebeInternalError):

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -8,11 +8,13 @@ from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 
 
 class TestShouldRetry:
-    def test_should_retry_no_current_retries(self, zeebe_adapter: ZeebeAdapterBase):
+    def test_returns_true_when_no_current_retries(
+        self, zeebe_adapter: ZeebeAdapterBase
+    ):
         zeebe_adapter._max_connection_retries = 1
         assert zeebe_adapter._should_retry()
 
-    def test_should_retry_current_retries_over_max(
+    def test_returns_false_when_current_retries_over_max(
         self, zeebe_adapter: ZeebeAdapterBase
     ):
         zeebe_adapter._max_connection_retries = 1

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -7,75 +7,77 @@ from pyzeebe.errors import (ZeebeBackPressureError,
 from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 
 
-def test_should_retry_no_current_retries(zeebe_adapter: ZeebeAdapterBase):
-    zeebe_adapter._max_connection_retries = 1
-    assert zeebe_adapter._should_retry()
+class TestShouldRetry:
+    def test_should_retry_no_current_retries(self, zeebe_adapter: ZeebeAdapterBase):
+        zeebe_adapter._max_connection_retries = 1
+        assert zeebe_adapter._should_retry()
 
-
-def test_should_retry_current_retries_over_max(zeebe_adapter: ZeebeAdapterBase):
-    zeebe_adapter._max_connection_retries = 1
-    zeebe_adapter._current_connection_retries = 1
-    assert not zeebe_adapter._should_retry()
-
-
-@pytest.mark.asyncio
-async def test_common_zeebe_grpc_error_internal(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(grpc.StatusCode.INTERNAL, None, None)
-    with pytest.raises(ZeebeInternalError):
-        await zeebe_adapter._common_zeebe_grpc_errors(error)
+    def test_should_retry_current_retries_over_max(
+        self, zeebe_adapter: ZeebeAdapterBase
+    ):
+        zeebe_adapter._max_connection_retries = 1
+        zeebe_adapter._current_connection_retries = 1
+        assert not zeebe_adapter._should_retry()
 
 
 @pytest.mark.asyncio
-async def test_common_zeebe_grpc_error_back_pressure(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED, None, None)
-    with pytest.raises(ZeebeBackPressureError):
-        await zeebe_adapter._common_zeebe_grpc_errors(error)
+class TestCommonZeebeGrpcErrors:
+    async def test_common_zeebe_grpc_error_internal(
+        self, zeebe_adapter: ZeebeAdapterBase
+    ):
+        error = grpc.aio.AioRpcError(grpc.StatusCode.INTERNAL, None, None)
+        with pytest.raises(ZeebeInternalError):
+            await zeebe_adapter._common_zeebe_grpc_errors(error)
 
+    async def test_common_zeebe_grpc_error_back_pressure(
+        self, zeebe_adapter: ZeebeAdapterBase
+    ):
+        error = grpc.aio.AioRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED, None, None)
+        with pytest.raises(ZeebeBackPressureError):
+            await zeebe_adapter._common_zeebe_grpc_errors(error)
 
-@pytest.mark.asyncio
-async def test_common_zeebe_grpc_error_gateway_unavailable(
-    zeebe_adapter: ZeebeAdapterBase,
-):
-    error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
-    with pytest.raises(ZeebeGatewayUnavailableError):
-        await zeebe_adapter._common_zeebe_grpc_errors(error)
+    async def test_common_zeebe_grpc_error_gateway_unavailable(
+        self,
+        zeebe_adapter: ZeebeAdapterBase,
+    ):
+        error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
+        with pytest.raises(ZeebeGatewayUnavailableError):
+            await zeebe_adapter._common_zeebe_grpc_errors(error)
 
+    async def test_common_zeebe_grpc_errors_raises_gateway_unavailable_on_cancelled(
+        self,
+        zeebe_adapter: ZeebeAdapterBase,
+    ):
+        error = grpc.aio.AioRpcError(grpc.StatusCode.CANCELLED, None, None)
 
-@pytest.mark.asyncio
-async def test_common_zeebe_grpc_errors_raises_gateway_unavailable_on_cancelled(
-    zeebe_adapter: ZeebeAdapterBase,
-):
-    error = grpc.aio.AioRpcError(grpc.StatusCode.CANCELLED, None, None)
+        with pytest.raises(ZeebeGatewayUnavailableError):
+            await zeebe_adapter._common_zeebe_grpc_errors(error)
 
-    with pytest.raises(ZeebeGatewayUnavailableError):
-        await zeebe_adapter._common_zeebe_grpc_errors(error)
+    async def test_common_zeebe_grpc_error_unkown_error(
+        self,
+        zeebe_adapter: ZeebeAdapterBase,
+    ):
+        error = grpc.aio.AioRpcError("FakeGrpcStatus", None, None)
+        with pytest.raises(grpc.aio.AioRpcError):
+            await zeebe_adapter._common_zeebe_grpc_errors(error)
 
+    async def test_close_after_retried_unavailable(
+        self, zeebe_adapter: ZeebeAdapterBase
+    ):
+        error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
 
-@pytest.mark.asyncio
-async def test_common_zeebe_grpc_error_unkown_error(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError("FakeGrpcStatus", None, None)
-    with pytest.raises(grpc.aio.AioRpcError):
-        await zeebe_adapter._common_zeebe_grpc_errors(error)
+        zeebe_adapter._close = AsyncMock()
+        zeebe_adapter._max_connection_retries = 1
+        with pytest.raises(ZeebeGatewayUnavailableError):
+            await zeebe_adapter._common_zeebe_grpc_errors(error)
 
+        zeebe_adapter._close.assert_called_once()
 
-@pytest.mark.asyncio
-async def test_close_after_retried_unavailable(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
+    async def test_close_after_retried_internal(self, zeebe_adapter: ZeebeAdapterBase):
+        error = grpc.aio.AioRpcError(grpc.StatusCode.INTERNAL, None, None)
+        zeebe_adapter._close = AsyncMock()
+        zeebe_adapter._max_connection_retries = 1
+        with pytest.raises(ZeebeInternalError):
+            await zeebe_adapter._common_zeebe_grpc_errors(error)
 
-    zeebe_adapter._close = AsyncMock()
-    zeebe_adapter._max_connection_retries = 1
-    with pytest.raises(ZeebeGatewayUnavailableError):
-        await zeebe_adapter._common_zeebe_grpc_errors(error)
-
-    zeebe_adapter._close.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_close_after_retried_internal(zeebe_adapter: ZeebeAdapterBase):
-    error = grpc.aio.AioRpcError(grpc.StatusCode.INTERNAL, None, None)
-    zeebe_adapter._close = AsyncMock()
-    zeebe_adapter._max_connection_retries = 1
-    with pytest.raises(ZeebeInternalError):
-        await zeebe_adapter._common_zeebe_grpc_errors(error)
-
-    zeebe_adapter._close.assert_called_once()
+        zeebe_adapter._close.assert_called_once()


### PR DESCRIPTION
When a zeebe gateway is restarted, the worker/client will receive a status of CANCELLED. This is currently not caught in pyzeebe. See #213 

## Changes

- Catch cancelled status and add to retry count

## API Updates

### New Features
none

### Deprecations
none

### Enhancements

- Make `ZeebeAdapterBase.is_error_status` accept a list of error statuses. Does not break current usages

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #213 