### PR TITLE
Fix audience value being just the cluster_id

### DIFF
--- a/pyzeebe/channel/camunda_cloud_channel.py
+++ b/pyzeebe/channel/camunda_cloud_channel.py
@@ -34,7 +34,7 @@ def create_camunda_cloud_channel(
         InvalidCamundaCloudCredentialsError: One of the provided camunda credentials is not correct
     """
     channel_credentials = _create_camunda_cloud_credentials(
-        client_id, client_secret, cluster_id
+        client_id, client_secret, cluster_id, region
     )
 
     return grpc.aio.secure_channel(
@@ -45,14 +45,14 @@ def create_camunda_cloud_channel(
 
 
 def _create_camunda_cloud_credentials(
-    client_id: str, client_secret: str, cluster_id: str
+    client_id: str, client_secret: str, cluster_id: str, region: str
 ) -> grpc.ChannelCredentials:
     try:
         access_token = _get_access_token(
             "https://login.cloud.camunda.io/oauth/token",
             client_id,
             client_secret,
-            cluster_id,
+            f"{cluster_id}.{region}.zeebe.camunda.io",
         )
         return _create_oauth_credentials(access_token)
     except InvalidOAuthCredentialsError as oauth_error:

--- a/tests/unit/channel/camunda_cloud_channel_test.py
+++ b/tests/unit/channel/camunda_cloud_channel_test.py
@@ -33,6 +33,11 @@ def cluster_id() -> str:
 
 
 @pytest.fixture
+def region() -> str:
+    return str(uuid4())
+
+
+@pytest.fixture
 def url() -> str:
     return "https://login.cloud.camunda.io/oauth/token"
 
@@ -88,12 +93,11 @@ class TestCamundaCloudChannel:
         client_id: str,
         client_secret: str,
         cluster_id: str,
+        region: str,
     ):
-        expected_request_body = (
-            f"client_id={client_id}&client_secret={client_secret}&audience={cluster_id}"
-        )
+        expected_request_body = f"client_id={client_id}&client_secret={client_secret}&audience={cluster_id}.{region}.zeebe.camunda.io"
 
-        create_camunda_cloud_channel(client_id, client_secret, cluster_id)
+        create_camunda_cloud_channel(client_id, client_secret, cluster_id, region)
 
         request = mocked_responses.calls[0].request
         assert request.body == expected_request_body


### PR DESCRIPTION
Fix audience value being just the cluster_id

## Changes

- Fix audience value in `create_camunda_cloud` that was causing `InvalidCamundaCloudCredentialsError`

## API Updates

### New Features
none

### Deprecations 
none

### Enhancements
none

## Checklist

- [x] Unit tests
- [x] Documentation

## References
Fixes #217 