### PR TITLE
Refactor/grpc internals

### DIFF
--- a/pyzeebe/client/client.py
+++ b/pyzeebe/client/client.py
@@ -36,6 +36,7 @@ class ZeebeClient(object):
             ZeebeBackPressureError: If Zeebe is currently in back pressure (too many requests)
             ZeebeGatewayUnavailableError: If the Zeebe gateway is unavailable
             ZeebeInternalError: If Zeebe experiences an internal error
+            UnkownGrpcStatusCodeError: If Zeebe returns an unexpected status code
 
         """
         return await self.zeebe_adapter.create_process_instance(
@@ -71,6 +72,7 @@ class ZeebeClient(object):
             ZeebeBackPressureError: If Zeebe is currently in back pressure (too many requests)
             ZeebeGatewayUnavailableError: If the Zeebe gateway is unavailable
             ZeebeInternalError: If Zeebe experiences an internal error
+            UnkownGrpcStatusCodeError: If Zeebe returns an unexpected status code
 
         """
         return await self.zeebe_adapter.create_process_instance_with_result(
@@ -96,6 +98,7 @@ class ZeebeClient(object):
             ZeebeBackPressureError: If Zeebe is currently in back pressure (too many requests)
             ZeebeGatewayUnavailableError: If the Zeebe gateway is unavailable
             ZeebeInternalError: If Zeebe experiences an internal error
+            UnkownGrpcStatusCodeError: If Zeebe returns an unexpected status code
 
         """
         await self.zeebe_adapter.cancel_process_instance(process_instance_key=process_instance_key)
@@ -113,6 +116,7 @@ class ZeebeClient(object):
             ZeebeBackPressureError: If Zeebe is currently in back pressure (too many requests)
             ZeebeGatewayUnavailableError: If the Zeebe gateway is unavailable
             ZeebeInternalError: If Zeebe experiences an internal error
+            UnkownGrpcStatusCodeError: If Zeebe returns an unexpected status code
 
         """
         await self.zeebe_adapter.deploy_process(*process_file_path)
@@ -141,6 +145,7 @@ class ZeebeClient(object):
             ZeebeBackPressureError: If Zeebe is currently in back pressure (too many requests)
             ZeebeGatewayUnavailableError: If the Zeebe gateway is unavailable
             ZeebeInternalError: If Zeebe experiences an internal error
+            UnkownGrpcStatusCodeError: If Zeebe returns an unexpected status code
 
         """
         await self.zeebe_adapter.publish_message(

--- a/pyzeebe/errors/zeebe_errors.py
+++ b/pyzeebe/errors/zeebe_errors.py
@@ -15,7 +15,7 @@ class ZeebeInternalError(PyZeebeError):
     pass
 
 
-class UnkownRpcStatusCodeError(PyZeebeError):
-    def __init__(self, rpc_error: grpc.aio.AioRpcError):
+class UnkownGrpcStatusCodeError(PyZeebeError):
+    def __init__(self, grpc_error: grpc.aio.AioRpcError):
         super().__init__()
-        self.rpc_error = rpc_error
+        self.grpc_error = grpc_error

--- a/pyzeebe/errors/zeebe_errors.py
+++ b/pyzeebe/errors/zeebe_errors.py
@@ -1,3 +1,5 @@
+import grpc
+
 from pyzeebe.errors.pyzeebe_errors import PyZeebeError
 
 
@@ -11,3 +13,9 @@ class ZeebeGatewayUnavailableError(PyZeebeError):
 
 class ZeebeInternalError(PyZeebeError):
     pass
+
+
+class UnkownRpcStatusCodeError(PyZeebeError):
+    def __init__(self, rpc_error: grpc.aio.AioRpcError):
+        super().__init__()
+        self.rpc_error = rpc_error

--- a/pyzeebe/grpc_internals/grpc_utils.py
+++ b/pyzeebe/grpc_internals/grpc_utils.py
@@ -1,0 +1,5 @@
+import grpc
+
+
+def is_error_status(rpc_error: grpc.aio.AioRpcError, *status_codes: grpc.StatusCode):
+    return rpc_error.code() in status_codes

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -32,12 +32,12 @@ class ZeebeAdapterBase:
             self._current_connection_retries += 1
             if not self._should_retry():
                 await self._close()
-            raise ZeebeGatewayUnavailableError()
+            raise ZeebeGatewayUnavailableError() from rpc_error
         elif is_error_status(rpc_error, grpc.StatusCode.INTERNAL):
             self._current_connection_retries += 1
             if not self._should_retry():
                 await self._close()
-            raise ZeebeInternalError()
+            raise ZeebeInternalError() from rpc_error
         else:
             raise rpc_error
 

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -1,6 +1,4 @@
 import logging
-import os
-from typing import Optional
 
 import grpc
 from zeebe_grpc.gateway_pb2_grpc import GatewayStub

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -4,10 +4,12 @@ import grpc
 from zeebe_grpc.gateway_pb2_grpc import GatewayStub
 
 from pyzeebe.errors import (
+    UnkownRpcStatusCodeError,
     ZeebeBackPressureError,
     ZeebeGatewayUnavailableError,
     ZeebeInternalError,
 )
+from pyzeebe.errors.pyzeebe_errors import PyZeebeError
 from pyzeebe.grpc_internals.grpc_utils import is_error_status
 
 logger = logging.getLogger(__name__)
@@ -25,24 +27,29 @@ class ZeebeAdapterBase:
     def _should_retry(self):
         return self._max_connection_retries == -1 or self._current_connection_retries < self._max_connection_retries
 
-    async def _common_zeebe_grpc_errors(self, rpc_error: grpc.aio.AioRpcError):
-        if is_error_status(rpc_error, grpc.StatusCode.RESOURCE_EXHAUSTED):
-            raise ZeebeBackPressureError()
-        elif is_error_status(rpc_error, grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.CANCELLED):
+    async def _handle_rpc_error(self, rpc_error: grpc.aio.AioRpcError):
+        try:
+            pyzeebe_error = _create_pyzeebe_error_from_grpc_error(rpc_error)
+            raise pyzeebe_error
+        except (ZeebeGatewayUnavailableError, ZeebeInternalError):
             self._current_connection_retries += 1
             if not self._should_retry():
                 await self._close()
-            raise ZeebeGatewayUnavailableError() from rpc_error
-        elif is_error_status(rpc_error, grpc.StatusCode.INTERNAL):
-            self._current_connection_retries += 1
-            if not self._should_retry():
-                await self._close()
-            raise ZeebeInternalError() from rpc_error
-        else:
-            raise rpc_error
+            raise
 
     async def _close(self):
         try:
             await self._channel.close()
         except Exception as exception:
             logger.exception(f"Failed to close channel, {type(exception).__name__} exception was raised")
+
+
+def _create_pyzeebe_error_from_grpc_error(rpc_error: grpc.aio.AioRpcError) -> PyZeebeError:
+    if is_error_status(rpc_error, grpc.StatusCode.RESOURCE_EXHAUSTED):
+        return ZeebeBackPressureError()
+    elif is_error_status(rpc_error, grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.CANCELLED):
+        return ZeebeGatewayUnavailableError()
+    elif is_error_status(rpc_error, grpc.StatusCode.INTERNAL):
+        return ZeebeInternalError()
+    else:
+        return UnkownRpcStatusCodeError(rpc_error)

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -51,5 +51,4 @@ def _create_pyzeebe_error_from_grpc_error(grpc_error: grpc.aio.AioRpcError) -> P
         return ZeebeGatewayUnavailableError()
     elif is_error_status(grpc_error, grpc.StatusCode.INTERNAL):
         return ZeebeInternalError()
-    else:
-        return UnkownGrpcStatusCodeError(grpc_error)
+    return UnkownGrpcStatusCodeError(grpc_error)

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -52,7 +52,7 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
                     yield job
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.INVALID_ARGUMENT):
-                raise ActivateJobsRequestInvalidError(task_type, worker, timeout, max_jobs_to_activate)
+                raise ActivateJobsRequestInvalidError(task_type, worker, timeout, max_jobs_to_activate) from rpc_error
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)
 
@@ -81,9 +81,9 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             )
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
-                raise JobNotFoundError(job_key=job_key)
+                raise JobNotFoundError(job_key=job_key) from rpc_error
             elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
-                raise JobAlreadyDeactivatedError(job_key=job_key)
+                raise JobAlreadyDeactivatedError(job_key=job_key) from rpc_error
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)
 
@@ -94,9 +94,9 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             )
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
-                raise JobNotFoundError(job_key=job_key)
+                raise JobNotFoundError(job_key=job_key) from rpc_error
             elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
-                raise JobAlreadyDeactivatedError(job_key=job_key)
+                raise JobAlreadyDeactivatedError(job_key=job_key) from rpc_error
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)
 
@@ -107,8 +107,8 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             )
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
-                raise JobNotFoundError(job_key=job_key)
+                raise JobNotFoundError(job_key=job_key) from rpc_error
             elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
-                raise JobAlreadyDeactivatedError(job_key=job_key)
+                raise JobAlreadyDeactivatedError(job_key=job_key) from rpc_error
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -18,6 +18,7 @@ from pyzeebe.errors import (
     JobAlreadyDeactivatedError,
     JobNotFoundError,
 )
+from pyzeebe.grpc_internals.grpc_utils import is_error_status
 from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 from pyzeebe.job.job import Job
 
@@ -50,7 +51,7 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
                     logger.debug(f"Got job: {job} from zeebe")
                     yield job
         except grpc.aio.AioRpcError as rpc_error:
-            if self.is_error_status(rpc_error, grpc.StatusCode.INVALID_ARGUMENT):
+            if is_error_status(rpc_error, grpc.StatusCode.INVALID_ARGUMENT):
                 raise ActivateJobsRequestInvalidError(task_type, worker, timeout, max_jobs_to_activate)
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)
@@ -79,9 +80,9 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
                 CompleteJobRequest(jobKey=job_key, variables=json.dumps(variables))
             )
         except grpc.aio.AioRpcError as rpc_error:
-            if self.is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
+            if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
                 raise JobNotFoundError(job_key=job_key)
-            elif self.is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
+            elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
                 raise JobAlreadyDeactivatedError(job_key=job_key)
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)
@@ -92,9 +93,9 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
                 FailJobRequest(jobKey=job_key, retries=retries, errorMessage=message)
             )
         except grpc.aio.AioRpcError as rpc_error:
-            if self.is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
+            if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
                 raise JobNotFoundError(job_key=job_key)
-            elif self.is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
+            elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
                 raise JobAlreadyDeactivatedError(job_key=job_key)
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)
@@ -105,9 +106,9 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
                 ThrowErrorRequest(jobKey=job_key, errorMessage=message, errorCode=error_code)
             )
         except grpc.aio.AioRpcError as rpc_error:
-            if self.is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
+            if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
                 raise JobNotFoundError(job_key=job_key)
-            elif self.is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
+            elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
                 raise JobAlreadyDeactivatedError(job_key=job_key)
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -50,10 +50,10 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
                     job = self._create_job_from_raw_job(raw_job)
                     logger.debug(f"Got job: {job} from zeebe")
                     yield job
-        except grpc.aio.AioRpcError as rpc_error:
-            if is_error_status(rpc_error, grpc.StatusCode.INVALID_ARGUMENT):
-                raise ActivateJobsRequestInvalidError(task_type, worker, timeout, max_jobs_to_activate) from rpc_error
-            await self._handle_rpc_error(rpc_error)
+        except grpc.aio.AioRpcError as grpc_error:
+            if is_error_status(grpc_error, grpc.StatusCode.INVALID_ARGUMENT):
+                raise ActivateJobsRequestInvalidError(task_type, worker, timeout, max_jobs_to_activate) from grpc_error
+            await self._handle_grpc_error(grpc_error)
 
     def _create_job_from_raw_job(self, response) -> Job:
         return Job(
@@ -78,33 +78,33 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             return await self._gateway_stub.CompleteJob(
                 CompleteJobRequest(jobKey=job_key, variables=json.dumps(variables))
             )
-        except grpc.aio.AioRpcError as rpc_error:
-            if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
-                raise JobNotFoundError(job_key=job_key) from rpc_error
-            elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
-                raise JobAlreadyDeactivatedError(job_key=job_key) from rpc_error
-            await self._handle_rpc_error(rpc_error)
+        except grpc.aio.AioRpcError as grpc_error:
+            if is_error_status(grpc_error, grpc.StatusCode.NOT_FOUND):
+                raise JobNotFoundError(job_key=job_key) from grpc_error
+            elif is_error_status(grpc_error, grpc.StatusCode.FAILED_PRECONDITION):
+                raise JobAlreadyDeactivatedError(job_key=job_key) from grpc_error
+            await self._handle_grpc_error(grpc_error)
 
     async def fail_job(self, job_key: int, retries: int, message: str) -> FailJobResponse:
         try:
             return await self._gateway_stub.FailJob(
                 FailJobRequest(jobKey=job_key, retries=retries, errorMessage=message)
             )
-        except grpc.aio.AioRpcError as rpc_error:
-            if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
-                raise JobNotFoundError(job_key=job_key) from rpc_error
-            elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
-                raise JobAlreadyDeactivatedError(job_key=job_key) from rpc_error
-            await self._handle_rpc_error(rpc_error)
+        except grpc.aio.AioRpcError as grpc_error:
+            if is_error_status(grpc_error, grpc.StatusCode.NOT_FOUND):
+                raise JobNotFoundError(job_key=job_key) from grpc_error
+            elif is_error_status(grpc_error, grpc.StatusCode.FAILED_PRECONDITION):
+                raise JobAlreadyDeactivatedError(job_key=job_key) from grpc_error
+            await self._handle_grpc_error(grpc_error)
 
     async def throw_error(self, job_key: int, message: str, error_code: str = "") -> ThrowErrorResponse:
         try:
             return await self._gateway_stub.ThrowError(
                 ThrowErrorRequest(jobKey=job_key, errorMessage=message, errorCode=error_code)
             )
-        except grpc.aio.AioRpcError as rpc_error:
-            if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
-                raise JobNotFoundError(job_key=job_key) from rpc_error
-            elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
-                raise JobAlreadyDeactivatedError(job_key=job_key) from rpc_error
-            await self._handle_rpc_error(rpc_error)
+        except grpc.aio.AioRpcError as grpc_error:
+            if is_error_status(grpc_error, grpc.StatusCode.NOT_FOUND):
+                raise JobNotFoundError(job_key=job_key) from grpc_error
+            elif is_error_status(grpc_error, grpc.StatusCode.FAILED_PRECONDITION):
+                raise JobAlreadyDeactivatedError(job_key=job_key) from grpc_error
+            await self._handle_grpc_error(grpc_error)

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -53,8 +53,7 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.INVALID_ARGUMENT):
                 raise ActivateJobsRequestInvalidError(task_type, worker, timeout, max_jobs_to_activate) from rpc_error
-            else:
-                await self._common_zeebe_grpc_errors(rpc_error)
+            await self._handle_rpc_error(rpc_error)
 
     def _create_job_from_raw_job(self, response) -> Job:
         return Job(
@@ -84,8 +83,7 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
                 raise JobNotFoundError(job_key=job_key) from rpc_error
             elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
                 raise JobAlreadyDeactivatedError(job_key=job_key) from rpc_error
-            else:
-                await self._common_zeebe_grpc_errors(rpc_error)
+            await self._handle_rpc_error(rpc_error)
 
     async def fail_job(self, job_key: int, retries: int, message: str) -> FailJobResponse:
         try:
@@ -97,8 +95,7 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
                 raise JobNotFoundError(job_key=job_key) from rpc_error
             elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
                 raise JobAlreadyDeactivatedError(job_key=job_key) from rpc_error
-            else:
-                await self._common_zeebe_grpc_errors(rpc_error)
+            await self._handle_rpc_error(rpc_error)
 
     async def throw_error(self, job_key: int, message: str, error_code: str = "") -> ThrowErrorResponse:
         try:
@@ -110,5 +107,4 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
                 raise JobNotFoundError(job_key=job_key) from rpc_error
             elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
                 raise JobAlreadyDeactivatedError(job_key=job_key) from rpc_error
-            else:
-                await self._common_zeebe_grpc_errors(rpc_error)
+            await self._handle_rpc_error(rpc_error)

--- a/pyzeebe/grpc_internals/zeebe_message_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_message_adapter.py
@@ -5,6 +5,7 @@ import grpc
 from zeebe_grpc.gateway_pb2 import PublishMessageRequest, PublishMessageResponse
 
 from pyzeebe.errors import MessageAlreadyExistsError
+from pyzeebe.grpc_internals.grpc_utils import is_error_status
 from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 
 
@@ -28,7 +29,7 @@ class ZeebeMessageAdapter(ZeebeAdapterBase):
                 )
             )
         except grpc.aio.AioRpcError as rpc_error:
-            if self.is_error_status(rpc_error, grpc.StatusCode.ALREADY_EXISTS):
+            if is_error_status(rpc_error, grpc.StatusCode.ALREADY_EXISTS):
                 raise MessageAlreadyExistsError()
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)

--- a/pyzeebe/grpc_internals/zeebe_message_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_message_adapter.py
@@ -28,7 +28,7 @@ class ZeebeMessageAdapter(ZeebeAdapterBase):
                     variables=json.dumps(variables),
                 )
             )
-        except grpc.aio.AioRpcError as rpc_error:
-            if is_error_status(rpc_error, grpc.StatusCode.ALREADY_EXISTS):
-                raise MessageAlreadyExistsError() from rpc_error
-            await self._handle_rpc_error(rpc_error)
+        except grpc.aio.AioRpcError as grpc_error:
+            if is_error_status(grpc_error, grpc.StatusCode.ALREADY_EXISTS):
+                raise MessageAlreadyExistsError() from grpc_error
+            await self._handle_grpc_error(grpc_error)

--- a/pyzeebe/grpc_internals/zeebe_message_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_message_adapter.py
@@ -31,5 +31,4 @@ class ZeebeMessageAdapter(ZeebeAdapterBase):
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.ALREADY_EXISTS):
                 raise MessageAlreadyExistsError() from rpc_error
-            else:
-                await self._common_zeebe_grpc_errors(rpc_error)
+            await self._handle_rpc_error(rpc_error)

--- a/pyzeebe/grpc_internals/zeebe_message_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_message_adapter.py
@@ -30,6 +30,6 @@ class ZeebeMessageAdapter(ZeebeAdapterBase):
             )
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.ALREADY_EXISTS):
-                raise MessageAlreadyExistsError()
+                raise MessageAlreadyExistsError() from rpc_error
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)

--- a/pyzeebe/grpc_internals/zeebe_process_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_process_adapter.py
@@ -67,8 +67,7 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
             raise ProcessDefinitionHasNoStartEventError(bpmn_process_id=bpmn_process_id) from rpc_error
         elif is_error_status(rpc_error, grpc.StatusCode.DEADLINE_EXCEEDED):
             raise ProcessTimeoutError(bpmn_process_id) from rpc_error
-        else:
-            await self._common_zeebe_grpc_errors(rpc_error)
+        await self._handle_rpc_error(rpc_error)
 
     async def cancel_process_instance(self, process_instance_key: int) -> None:
         try:
@@ -78,8 +77,7 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
                 raise ProcessInstanceNotFoundError(process_instance_key=process_instance_key) from rpc_error
-            else:
-                await self._common_zeebe_grpc_errors(rpc_error)
+            await self._handle_rpc_error(rpc_error)
 
     async def deploy_process(self, *process_file_path: str) -> DeployProcessResponse:
         try:
@@ -91,8 +89,7 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.INVALID_ARGUMENT):
                 raise ProcessInvalidError() from rpc_error
-            else:
-                await self._common_zeebe_grpc_errors(rpc_error)
+            await self._handle_rpc_error(rpc_error)
 
     @staticmethod
     async def _get_process_request_object(process_file_path: str) -> ProcessRequestObject:

--- a/pyzeebe/grpc_internals/zeebe_process_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_process_adapter.py
@@ -83,7 +83,7 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
         try:
             return await self._gateway_stub.DeployProcess(
                 DeployProcessRequest(
-                    processes=[await result for result in map(self._get_process_request_object, process_file_path)]
+                    processes=[await result for result in map(_create_process_request, process_file_path)]
                 )
             )
         except grpc.aio.AioRpcError as grpc_error:
@@ -91,7 +91,7 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
                 raise ProcessInvalidError() from grpc_error
             await self._handle_grpc_error(grpc_error)
 
-    @staticmethod
-    async def _get_process_request_object(process_file_path: str) -> ProcessRequestObject:
-        async with aiofiles.open(process_file_path, "rb") as file:
-            return ProcessRequestObject(name=os.path.basename(process_file_path), definition=await file.read())
+
+async def _create_process_request(process_file_path: str) -> ProcessRequestObject:
+    async with aiofiles.open(process_file_path, "rb") as file:
+        return ProcessRequestObject(name=os.path.basename(process_file_path), definition=await file.read())

--- a/pyzeebe/grpc_internals/zeebe_process_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_process_adapter.py
@@ -33,8 +33,8 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
                     bpmnProcessId=bpmn_process_id, version=version, variables=json.dumps(variables)
                 )
             )
-        except grpc.aio.AioRpcError as rpc_error:
-            await self._create_process_errors(rpc_error, bpmn_process_id, version, variables)
+        except grpc.aio.AioRpcError as grpc_error:
+            await self._create_process_errors(grpc_error, bpmn_process_id, version, variables)
         return response.processInstanceKey
 
     async def create_process_instance_with_result(
@@ -50,34 +50,34 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
                     fetchVariables=variables_to_fetch,
                 )
             )
-        except grpc.aio.AioRpcError as rpc_error:
-            await self._create_process_errors(rpc_error, bpmn_process_id, version, variables)
+        except grpc.aio.AioRpcError as grpc_error:
+            await self._create_process_errors(grpc_error, bpmn_process_id, version, variables)
         return response.processInstanceKey, json.loads(response.variables)
 
     async def _create_process_errors(
-        self, rpc_error: grpc.aio.AioRpcError, bpmn_process_id: str, version: int, variables: Dict
+        self, grpc_error: grpc.aio.AioRpcError, bpmn_process_id: str, version: int, variables: Dict
     ) -> None:
-        if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
-            raise ProcessDefinitionNotFoundError(bpmn_process_id=bpmn_process_id, version=version) from rpc_error
-        elif is_error_status(rpc_error, grpc.StatusCode.INVALID_ARGUMENT):
+        if is_error_status(grpc_error, grpc.StatusCode.NOT_FOUND):
+            raise ProcessDefinitionNotFoundError(bpmn_process_id=bpmn_process_id, version=version) from grpc_error
+        elif is_error_status(grpc_error, grpc.StatusCode.INVALID_ARGUMENT):
             raise InvalidJSONError(
                 f"Cannot start process: {bpmn_process_id} with version {version}. Variables: {variables}"
-            ) from rpc_error
-        elif is_error_status(rpc_error, grpc.StatusCode.FAILED_PRECONDITION):
-            raise ProcessDefinitionHasNoStartEventError(bpmn_process_id=bpmn_process_id) from rpc_error
-        elif is_error_status(rpc_error, grpc.StatusCode.DEADLINE_EXCEEDED):
-            raise ProcessTimeoutError(bpmn_process_id) from rpc_error
-        await self._handle_rpc_error(rpc_error)
+            ) from grpc_error
+        elif is_error_status(grpc_error, grpc.StatusCode.FAILED_PRECONDITION):
+            raise ProcessDefinitionHasNoStartEventError(bpmn_process_id=bpmn_process_id) from grpc_error
+        elif is_error_status(grpc_error, grpc.StatusCode.DEADLINE_EXCEEDED):
+            raise ProcessTimeoutError(bpmn_process_id) from grpc_error
+        await self._handle_grpc_error(grpc_error)
 
     async def cancel_process_instance(self, process_instance_key: int) -> None:
         try:
             await self._gateway_stub.CancelProcessInstance(
                 CancelProcessInstanceRequest(processInstanceKey=process_instance_key)
             )
-        except grpc.aio.AioRpcError as rpc_error:
-            if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
-                raise ProcessInstanceNotFoundError(process_instance_key=process_instance_key) from rpc_error
-            await self._handle_rpc_error(rpc_error)
+        except grpc.aio.AioRpcError as grpc_error:
+            if is_error_status(grpc_error, grpc.StatusCode.NOT_FOUND):
+                raise ProcessInstanceNotFoundError(process_instance_key=process_instance_key) from grpc_error
+            await self._handle_grpc_error(grpc_error)
 
     async def deploy_process(self, *process_file_path: str) -> DeployProcessResponse:
         try:
@@ -86,10 +86,10 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
                     processes=[await result for result in map(self._get_process_request_object, process_file_path)]
                 )
             )
-        except grpc.aio.AioRpcError as rpc_error:
-            if is_error_status(rpc_error, grpc.StatusCode.INVALID_ARGUMENT):
-                raise ProcessInvalidError() from rpc_error
-            await self._handle_rpc_error(rpc_error)
+        except grpc.aio.AioRpcError as grpc_error:
+            if is_error_status(grpc_error, grpc.StatusCode.INVALID_ARGUMENT):
+                raise ProcessInvalidError() from grpc_error
+            await self._handle_grpc_error(grpc_error)
 
     @staticmethod
     async def _get_process_request_object(process_file_path: str) -> ProcessRequestObject:

--- a/pyzeebe/grpc_internals/zeebe_process_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_process_adapter.py
@@ -77,7 +77,7 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
             )
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.NOT_FOUND):
-                raise ProcessInstanceNotFoundError(process_instance_key=process_instance_key)
+                raise ProcessInstanceNotFoundError(process_instance_key=process_instance_key) from rpc_error
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)
 
@@ -90,7 +90,7 @@ class ZeebeProcessAdapter(ZeebeAdapterBase):
             )
         except grpc.aio.AioRpcError as rpc_error:
             if is_error_status(rpc_error, grpc.StatusCode.INVALID_ARGUMENT):
-                raise ProcessInvalidError()
+                raise ProcessInvalidError() from rpc_error
             else:
                 await self._common_zeebe_grpc_errors(rpc_error)
 

--- a/pyzeebe/worker/worker.py
+++ b/pyzeebe/worker/worker.py
@@ -60,6 +60,7 @@ class ZeebeWorker(ZeebeTaskRouter):
             ZeebeBackPressureError: If Zeebe is currently in back pressure (too many requests)
             ZeebeGatewayUnavailableError: If the Zeebe gateway is unavailable
             ZeebeInternalError: If Zeebe experiences an internal error
+            UnkownGrpcStatusCodeError: If Zeebe returns an unexpected status code
 
         """
         self._job_executors, self._job_pollers = [], []

--- a/tests/unit/grpc_internals/grpc_utils_test.py
+++ b/tests/unit/grpc_internals/grpc_utils_test.py
@@ -1,0 +1,18 @@
+import grpc
+
+from pyzeebe.grpc_internals import grpc_utils
+
+
+class TestIsErrorStatus:
+    error = grpc.aio.AioRpcError(grpc.StatusCode.OK, None, None)
+    matching_status_code = grpc.StatusCode.OK
+    unmatching_status_code = grpc.StatusCode.UNKNOWN
+
+    def test_with_matching_code_returns_true(self):
+        assert grpc_utils.is_error_status(self.error, self.matching_status_code)
+
+    def test_with_no_matching_code_returns_false(self):
+        assert not grpc_utils.is_error_status(self.error, self.unmatching_status_code)
+
+    def test_with_matching_and_unmatching_code_returns_true(self):
+        assert grpc_utils.is_error_status(self.error, self.matching_status_code, self.unmatching_status_code)

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -7,7 +7,7 @@ from pyzeebe.errors import (
     ZeebeGatewayUnavailableError,
     ZeebeInternalError,
 )
-from pyzeebe.errors.zeebe_errors import UnkownRpcStatusCodeError
+from pyzeebe.errors.zeebe_errors import UnkownGrpcStatusCodeError
 from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 
 
@@ -27,12 +27,12 @@ class TestHandleRpcError:
     async def test_raises_internal_error_on_internal_error_status(self, zeebe_adapter: ZeebeAdapterBase):
         error = grpc.aio.AioRpcError(grpc.StatusCode.INTERNAL, None, None)
         with pytest.raises(ZeebeInternalError):
-            await zeebe_adapter._handle_rpc_error(error)
+            await zeebe_adapter._handle_grpc_error(error)
 
     async def test_raises_back_pressure_error_on_resource_exhausted(self, zeebe_adapter: ZeebeAdapterBase):
         error = grpc.aio.AioRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED, None, None)
         with pytest.raises(ZeebeBackPressureError):
-            await zeebe_adapter._handle_rpc_error(error)
+            await zeebe_adapter._handle_grpc_error(error)
 
     async def test_raises_gateway_unavailable_on_unavailable_status(
         self,
@@ -40,7 +40,7 @@ class TestHandleRpcError:
     ):
         error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
         with pytest.raises(ZeebeGatewayUnavailableError):
-            await zeebe_adapter._handle_rpc_error(error)
+            await zeebe_adapter._handle_grpc_error(error)
 
     async def test_raises_gateway_unavailable_on_cancelled_status(
         self,
@@ -49,15 +49,15 @@ class TestHandleRpcError:
         error = grpc.aio.AioRpcError(grpc.StatusCode.CANCELLED, None, None)
 
         with pytest.raises(ZeebeGatewayUnavailableError):
-            await zeebe_adapter._handle_rpc_error(error)
+            await zeebe_adapter._handle_grpc_error(error)
 
     async def test_raises_unkown_grpc_status_code_on_unkown_status_code(
         self,
         zeebe_adapter: ZeebeAdapterBase,
     ):
         error = grpc.aio.AioRpcError("FakeGrpcStatus", None, None)
-        with pytest.raises(UnkownRpcStatusCodeError):
-            await zeebe_adapter._handle_rpc_error(error)
+        with pytest.raises(UnkownGrpcStatusCodeError):
+            await zeebe_adapter._handle_grpc_error(error)
 
     async def test_closes_after_retries_exceeded(self, zeebe_adapter: ZeebeAdapterBase):
         error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
@@ -65,7 +65,7 @@ class TestHandleRpcError:
         zeebe_adapter._close = AsyncMock()
         zeebe_adapter._max_connection_retries = 1
         with pytest.raises(ZeebeGatewayUnavailableError):
-            await zeebe_adapter._handle_rpc_error(error)
+            await zeebe_adapter._handle_grpc_error(error)
 
         zeebe_adapter._close.assert_called_once()
 
@@ -74,6 +74,6 @@ class TestHandleRpcError:
         zeebe_adapter._close = AsyncMock()
         zeebe_adapter._max_connection_retries = 1
         with pytest.raises(ZeebeInternalError):
-            await zeebe_adapter._handle_rpc_error(error)
+            await zeebe_adapter._handle_grpc_error(error)
 
         zeebe_adapter._close.assert_called_once()

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -7,6 +7,7 @@ from pyzeebe.errors import (
     ZeebeGatewayUnavailableError,
     ZeebeInternalError,
 )
+from pyzeebe.errors.zeebe_errors import UnkownRpcStatusCodeError
 from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 
 
@@ -22,16 +23,16 @@ class TestShouldRetry:
 
 
 @pytest.mark.asyncio
-class TestCommonZeebeGrpcErrors:
+class TestHandleRpcError:
     async def test_raises_internal_error_on_internal_error_status(self, zeebe_adapter: ZeebeAdapterBase):
         error = grpc.aio.AioRpcError(grpc.StatusCode.INTERNAL, None, None)
         with pytest.raises(ZeebeInternalError):
-            await zeebe_adapter._common_zeebe_grpc_errors(error)
+            await zeebe_adapter._handle_rpc_error(error)
 
     async def test_raises_back_pressure_error_on_resource_exhausted(self, zeebe_adapter: ZeebeAdapterBase):
         error = grpc.aio.AioRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED, None, None)
         with pytest.raises(ZeebeBackPressureError):
-            await zeebe_adapter._common_zeebe_grpc_errors(error)
+            await zeebe_adapter._handle_rpc_error(error)
 
     async def test_raises_gateway_unavailable_on_unavailable_status(
         self,
@@ -39,7 +40,7 @@ class TestCommonZeebeGrpcErrors:
     ):
         error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
         with pytest.raises(ZeebeGatewayUnavailableError):
-            await zeebe_adapter._common_zeebe_grpc_errors(error)
+            await zeebe_adapter._handle_rpc_error(error)
 
     async def test_raises_gateway_unavailable_on_cancelled_status(
         self,
@@ -48,15 +49,15 @@ class TestCommonZeebeGrpcErrors:
         error = grpc.aio.AioRpcError(grpc.StatusCode.CANCELLED, None, None)
 
         with pytest.raises(ZeebeGatewayUnavailableError):
-            await zeebe_adapter._common_zeebe_grpc_errors(error)
+            await zeebe_adapter._handle_rpc_error(error)
 
-    async def test_reraises_unkown_error(
+    async def test_raises_unkown_grpc_status_code_on_unkown_status_code(
         self,
         zeebe_adapter: ZeebeAdapterBase,
     ):
         error = grpc.aio.AioRpcError("FakeGrpcStatus", None, None)
-        with pytest.raises(grpc.aio.AioRpcError):
-            await zeebe_adapter._common_zeebe_grpc_errors(error)
+        with pytest.raises(UnkownRpcStatusCodeError):
+            await zeebe_adapter._handle_rpc_error(error)
 
     async def test_closes_after_retries_exceeded(self, zeebe_adapter: ZeebeAdapterBase):
         error = grpc.aio.AioRpcError(grpc.StatusCode.UNAVAILABLE, None, None)
@@ -64,7 +65,7 @@ class TestCommonZeebeGrpcErrors:
         zeebe_adapter._close = AsyncMock()
         zeebe_adapter._max_connection_retries = 1
         with pytest.raises(ZeebeGatewayUnavailableError):
-            await zeebe_adapter._common_zeebe_grpc_errors(error)
+            await zeebe_adapter._handle_rpc_error(error)
 
         zeebe_adapter._close.assert_called_once()
 
@@ -73,6 +74,6 @@ class TestCommonZeebeGrpcErrors:
         zeebe_adapter._close = AsyncMock()
         zeebe_adapter._max_connection_retries = 1
         with pytest.raises(ZeebeInternalError):
-            await zeebe_adapter._common_zeebe_grpc_errors(error)
+            await zeebe_adapter._handle_rpc_error(error)
 
         zeebe_adapter._close.assert_called_once()


### PR DESCRIPTION
A little refactor of the`grpc_internals` module

## Changes

- Raise `UnkownGrpcStatusCodeError` for unkown grpc status codes instead of reraising the grpc error
- Raise pyzeebe errors from the grpc error to improve stack trace
- General improvements to the code base

## API Updates

### New Features

none

### Deprecations 

none

### Enhancements

- Raise exceptions from base grpc exceptions
- Wrap grpc exception in `UnkownGrpcStatusCodeError` when encountering an unkown grpc status code


## Checklist

- [x] Unit tests
- [x] Documentation

