### PR TITLE
Use lazy formatting in log calls

### DIFF
--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -41,7 +41,7 @@ class ZeebeAdapterBase:
         try:
             await self._channel.close()
         except Exception as exception:
-            logger.exception(f"Failed to close channel, {type(exception).__name__} exception was raised")
+            logger.exception("Failed to close channel, %s exception was raised", type(exception).__name__)
 
 
 def _create_pyzeebe_error_from_grpc_error(grpc_error: grpc.aio.AioRpcError) -> PyZeebeError:

--- a/pyzeebe/grpc_internals/zeebe_job_adapter.py
+++ b/pyzeebe/grpc_internals/zeebe_job_adapter.py
@@ -48,7 +48,7 @@ class ZeebeJobAdapter(ZeebeAdapterBase):
             ):
                 for raw_job in response.jobs:
                     job = self._create_job_from_raw_job(raw_job)
-                    logger.debug(f"Got job: {job} from zeebe")
+                    logger.debug("Got job: %s from zeebe", job)
                     yield job
         except grpc.aio.AioRpcError as grpc_error:
             if is_error_status(grpc_error, grpc.StatusCode.INVALID_ARGUMENT):

--- a/pyzeebe/task/task_builder.py
+++ b/pyzeebe/task/task_builder.py
@@ -56,7 +56,7 @@ async def run_original_task_function(
     try:
         return await task_function(**job.variables), True  # type: ignore
     except Exception as e:
-        logger.debug(f"Failed job: {job}. Error: {e}.")
+        logger.debug("Failed job: %s. Error: %s.", job, e)
         await task_config.exception_handler(e, job)
         return job.variables, False
 
@@ -74,5 +74,5 @@ async def run_decorator(decorator: AsyncTaskDecorator, job: Job) -> Job:
     try:
         return await decorator(job)
     except Exception as e:
-        logger.warning(f"Failed to run decorator {decorator}. Exception: {e}")
+        logger.warning("Failed to run decorator %s. Exception: %s", decorator, e)
         return job

--- a/pyzeebe/worker/job_executor.py
+++ b/pyzeebe/worker/job_executor.py
@@ -33,7 +33,7 @@ class JobExecutor:
         try:
             await self.task.job_handler(job)
         except JobAlreadyDeactivatedError as error:
-            logger.warning(f"Job was already deactivated. Job key: {error.job_key}")
+            logger.warning("Job was already deactivated. Job key: %s", error.job_key)
 
     def should_execute(self) -> bool:
         return not self.stop_event.is_set()

--- a/pyzeebe/worker/job_poller.py
+++ b/pyzeebe/worker/job_poller.py
@@ -43,7 +43,9 @@ class JobPoller:
             await self.poll_once()
         else:
             logger.warning(
-                f"Maximum number of jobs running for {self.task.type}. Polling again in {self.poll_retry_delay} seconds..."
+                "Maximum number of jobs running for %s. Polling again in %s seconds...",
+                self.task.type,
+                self.poll_retry_delay,
             )
             await asyncio.sleep(self.poll_retry_delay)
 
@@ -61,11 +63,12 @@ class JobPoller:
                 self.task_state.add(job)
                 await self.queue.put(job)
         except ActivateJobsRequestInvalidError:
-            logger.warning(f"Activate job requests was invalid for task {self.task.type}")
+            logger.warning("Activate job requests was invalid for task %s", self.task.type)
             raise
         except (ZeebeBackPressureError, ZeebeGatewayUnavailableError, ZeebeInternalError) as error:
             logger.warning(
-                f"Failed to activate jobs from the gateway. Exception: {repr(error)}. Retrying in 5 seconds..."
+                "Failed to activate jobs from the gateway. Exception: %s. Retrying in 5 seconds...",
+                repr(error),
             )
             await asyncio.sleep(5)
 

--- a/pyzeebe/worker/task_router.py
+++ b/pyzeebe/worker/task_router.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 async def default_exception_handler(e: Exception, job: Job) -> None:
-    logger.warning(f"Task type: {job.type} - failed job {job}. Error: {e}.")
+    logger.warning("Task type: %s - failed job %s. Error: %s.", job.type, job, e)
     if isinstance(e, BusinessError):
         await job.set_error_status(f"Failed job. Recoverable error: {e}", error_code=e.error_code)
     else:

--- a/pyzeebe/worker/task_state.py
+++ b/pyzeebe/worker/task_state.py
@@ -13,7 +13,7 @@ class TaskState:
         try:
             self._active_jobs.remove(job.key)
         except ValueError:
-            logger.warning(f"Could not find Job key {job.key} when trying to remove from TaskState")
+            logger.warning("Could not find Job key %s when trying to remove from TaskState", job.key)
 
     def add(self, job: Job) -> None:
         self._active_jobs.append(job.key)


### PR DESCRIPTION
Format log messages lazily. This way `logging` will take care of a potential exception.

## Changes

- Format log messaging lazy style