### PR TITLE
Build router tasks before adding them

### DIFF
--- a/pyzeebe/worker/worker.py
+++ b/pyzeebe/worker/worker.py
@@ -7,6 +7,7 @@ import grpc
 
 from pyzeebe import TaskDecorator
 from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
+from pyzeebe.task import task_builder
 from pyzeebe.worker.job_executor import JobExecutor
 from pyzeebe.worker.job_poller import JobPoller
 from pyzeebe.worker.task_router import ZeebeTaskRouter
@@ -117,5 +118,6 @@ class ZeebeWorker(ZeebeTaskRouter):
         """
         for router in routers:
             for task in router.tasks:
-                task.config = self._add_decorators_to_config(task.config)
+                config_with_decorators = self._add_decorators_to_config(task.config)
+                task = task_builder.build_task(task.original_function, config_with_decorators)
                 self._add_task(task)

--- a/tests/unit/worker/worker_test.py
+++ b/tests/unit/worker/worker_test.py
@@ -100,6 +100,28 @@ class TestIncludeRouter:
 
         decorator.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_worker_with_before_decorator(
+        self, zeebe_worker: ZeebeWorker, router: ZeebeTaskRouter, decorator: TaskDecorator, mocked_job_with_adapter: Job
+    ):
+        zeebe_worker.before(decorator)
+        task = self.include_router_with_task(zeebe_worker, router)
+
+        await task.job_handler(mocked_job_with_adapter)
+
+        decorator.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_worker_with_after_decorator(
+        self, zeebe_worker: ZeebeWorker, router: ZeebeTaskRouter, decorator: TaskDecorator, mocked_job_with_adapter: Job
+    ):
+        zeebe_worker.after(decorator)
+        task = self.include_router_with_task(zeebe_worker, router)
+
+        await task.job_handler(mocked_job_with_adapter)
+
+        decorator.assert_called_once()
+
     @staticmethod
     def include_router_with_task(zeebe_worker: ZeebeWorker, router: ZeebeTaskRouter, task_type: str = None) -> Task:
         task_type = task_type or str(uuid4())


### PR DESCRIPTION
Fix decorators not being added to router tasks.

## Changes

- Build task before adding it to router.

## API Updates
None.

### New Features *(required)*
None.

### Deprecations *(required)*
None.

### Enhancements *(optional)*
Passing decorators to a worker now works and applies the decorators to each task.

## Checklist

- [x] Unit tests
- [X] Documentation

## References

(optional)

Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations
that helped put this solution together. This helps ensure there is a good aggregation
of resources regarding the implementation.

Fixes #282