### PR TITLE
Bugfix/set job status

### DIFF
--- a/pyzeebe/job/job.py
+++ b/pyzeebe/job/job.py
@@ -51,6 +51,7 @@ class Job(object):
             ZeebeInternalError: If Zeebe experiences an internal error
 
         """
+        self.status = JobStatus.Completed
         if self.zeebe_adapter:
             await self.zeebe_adapter.complete_job(job_key=self.key, variables=self.variables)
         else:
@@ -71,6 +72,7 @@ class Job(object):
             ZeebeInternalError: If Zeebe experiences an internal error
 
         """
+        self.status = JobStatus.Failed
         if self.zeebe_adapter:
             await self.zeebe_adapter.fail_job(job_key=self.key, retries=self.retries - 1, message=message)
         else:
@@ -93,6 +95,7 @@ class Job(object):
             ZeebeInternalError: If Zeebe experiences an internal error
 
         """
+        self.status = JobStatus.ErrorThrown
         if self.zeebe_adapter:
             await self.zeebe_adapter.throw_error(job_key=self.key, message=message, error_code=error_code)
         else:

--- a/pyzeebe/job/job.py
+++ b/pyzeebe/job/job.py
@@ -51,8 +51,8 @@ class Job(object):
             ZeebeInternalError: If Zeebe experiences an internal error
 
         """
-        self.status = JobStatus.Completed
         if self.zeebe_adapter:
+            self.status = JobStatus.Completed
             await self.zeebe_adapter.complete_job(job_key=self.key, variables=self.variables)
         else:
             raise NoZeebeAdapterError()
@@ -72,8 +72,8 @@ class Job(object):
             ZeebeInternalError: If Zeebe experiences an internal error
 
         """
-        self.status = JobStatus.Failed
         if self.zeebe_adapter:
+            self.status = JobStatus.Failed
             await self.zeebe_adapter.fail_job(job_key=self.key, retries=self.retries - 1, message=message)
         else:
             raise NoZeebeAdapterError()
@@ -95,8 +95,8 @@ class Job(object):
             ZeebeInternalError: If Zeebe experiences an internal error
 
         """
-        self.status = JobStatus.ErrorThrown
         if self.zeebe_adapter:
+            self.status = JobStatus.ErrorThrown
             await self.zeebe_adapter.throw_error(job_key=self.key, message=message, error_code=error_code)
         else:
             raise NoZeebeAdapterError()

--- a/tests/unit/job/job_test.py
+++ b/tests/unit/job/job_test.py
@@ -8,75 +8,87 @@ from pyzeebe.errors import NoZeebeAdapterError
 
 
 @pytest.mark.asyncio
-async def test_success(job_with_adapter):
-    complete_job_mock = AsyncMock()
-    job_with_adapter.zeebe_adapter.complete_job = complete_job_mock
+class TestSetSuccessStatus:
+    async def test_updates_job_in_zeebe(self, job_with_adapter):
+        complete_job_mock = AsyncMock()
+        job_with_adapter.zeebe_adapter.complete_job = complete_job_mock
 
-    await job_with_adapter.set_success_status()
+        await job_with_adapter.set_success_status()
 
-    complete_job_mock.assert_called_with(job_key=job_with_adapter.key, variables=job_with_adapter.variables)
-    assert job_with_adapter.status == JobStatus.Completed
+        complete_job_mock.assert_called_with(job_key=job_with_adapter.key, variables=job_with_adapter.variables)
 
+    async def test_status_is_set(self, job_with_adapter):
+        complete_job_mock = AsyncMock()
+        job_with_adapter.zeebe_adapter.complete_job = complete_job_mock
 
-@pytest.mark.asyncio
-async def test_success_no_zeebe_adapter(job_without_adapter):
-    with pytest.raises(NoZeebeAdapterError):
-        await job_without_adapter.set_success_status()
+        await job_with_adapter.set_success_status()
 
+        assert job_with_adapter.status == JobStatus.Completed
 
-@pytest.mark.asyncio
-async def test_error(job_with_adapter):
-    throw_error_mock = AsyncMock()
-    job_with_adapter.zeebe_adapter.throw_error = throw_error_mock
-    message = str(uuid4())
-
-    await job_with_adapter.set_error_status(message)
-
-    throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code="")
-    assert job_with_adapter.status == JobStatus.ErrorThrown
+    async def test_raises_without_zeebe_adapter(self, job_without_adapter):
+        with pytest.raises(NoZeebeAdapterError):
+            await job_without_adapter.set_success_status()
 
 
 @pytest.mark.asyncio
-async def test_error_with_code(job_with_adapter):
-    throw_error_mock = AsyncMock()
-    job_with_adapter.zeebe_adapter.throw_error = throw_error_mock
-    message = str(uuid4())
-    error_code = "custom-error-code"
-
-    await job_with_adapter.set_error_status(message, error_code)
-
-    throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code=error_code)
-    assert job_with_adapter.status == JobStatus.ErrorThrown
-
-
-@pytest.mark.asyncio
-async def test_error_no_zeebe_adapter(job_without_adapter):
-    with pytest.raises(NoZeebeAdapterError):
+class TestSetErrorStatus:
+    async def test_updates_job_in_zeebe(self, job_with_adapter):
+        throw_error_mock = AsyncMock()
+        job_with_adapter.zeebe_adapter.throw_error = throw_error_mock
         message = str(uuid4())
-        await job_without_adapter.set_error_status(message)
 
+        await job_with_adapter.set_error_status(message)
 
-@pytest.mark.asyncio
-async def test_failure(job_with_adapter):
-    fail_job_mock = AsyncMock()
-    job_with_adapter.zeebe_adapter.fail_job = fail_job_mock
-    message = str(uuid4())
+        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code="")
 
-    await job_with_adapter.set_failure_status(message)
-
-    fail_job_mock.assert_called_with(
-        job_key=job_with_adapter.key, retries=job_with_adapter.retries - 1, message=message
-    )
-    assert job_with_adapter.status == JobStatus.Failed
-
-
-@pytest.mark.asyncio
-async def test_failure_no_zeebe_adapter(job_without_adapter):
-    with pytest.raises(NoZeebeAdapterError):
+    async def test_updates_job_in_zeebe_with_code(self, job_with_adapter):
+        throw_error_mock = AsyncMock()
+        job_with_adapter.zeebe_adapter.throw_error = throw_error_mock
         message = str(uuid4())
-        await job_without_adapter.set_failure_status(message)
+        error_code = "custom-error-code"
+
+        await job_with_adapter.set_error_status(message, error_code)
+
+        throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code=error_code)
+
+    async def test_status_is_set(self, job_with_adapter):
+        throw_error_mock = AsyncMock()
+        job_with_adapter.zeebe_adapter.throw_error = throw_error_mock
+        message = str(uuid4())
+
+        await job_with_adapter.set_error_status(message)
+
+        assert job_with_adapter.status == JobStatus.ErrorThrown
+
+    async def test_raises_without_zeebe_adapter(self, job_without_adapter):
+        with pytest.raises(NoZeebeAdapterError):
+            message = str(uuid4())
+            await job_without_adapter.set_error_status(message)
 
 
-def test_equality_raises_not_implemented_on_other_type(job_without_adapter: Job):
-    with pytest.raises(NotImplementedError):
-        job_without_adapter == "test"
+@pytest.mark.asyncio
+class TestSetFailureStatus:
+    async def test_updates_job_in_zeebe(self, job_with_adapter):
+        fail_job_mock = AsyncMock()
+        job_with_adapter.zeebe_adapter.fail_job = fail_job_mock
+        message = str(uuid4())
+
+        await job_with_adapter.set_failure_status(message)
+
+        fail_job_mock.assert_called_with(
+            job_key=job_with_adapter.key, retries=job_with_adapter.retries - 1, message=message
+        )
+
+    async def test_status_is_set(self, job_with_adapter):
+        fail_job_mock = AsyncMock()
+        job_with_adapter.zeebe_adapter.fail_job = fail_job_mock
+        message = str(uuid4())
+
+        await job_with_adapter.set_failure_status(message)
+
+        assert job_with_adapter.status == JobStatus.Failed
+
+    async def test_raises_without_zeebe_adapter(self, job_without_adapter):
+        with pytest.raises(NoZeebeAdapterError):
+            message = str(uuid4())
+            await job_without_adapter.set_failure_status(message)

--- a/tests/unit/job/job_test.py
+++ b/tests/unit/job/job_test.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 import pytest
 from mock import AsyncMock
 
-from pyzeebe import Job
+from pyzeebe import Job, JobStatus
 from pyzeebe.errors import NoZeebeAdapterError
 
 
@@ -15,6 +15,7 @@ async def test_success(job_with_adapter):
     await job_with_adapter.set_success_status()
 
     complete_job_mock.assert_called_with(job_key=job_with_adapter.key, variables=job_with_adapter.variables)
+    assert job_with_adapter.status == JobStatus.Completed
 
 
 @pytest.mark.asyncio
@@ -32,6 +33,7 @@ async def test_error(job_with_adapter):
     await job_with_adapter.set_error_status(message)
 
     throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code="")
+    assert job_with_adapter.status == JobStatus.ErrorThrown
 
 
 @pytest.mark.asyncio
@@ -44,6 +46,7 @@ async def test_error_with_code(job_with_adapter):
     await job_with_adapter.set_error_status(message, error_code)
 
     throw_error_mock.assert_called_with(job_key=job_with_adapter.key, message=message, error_code=error_code)
+    assert job_with_adapter.status == JobStatus.ErrorThrown
 
 
 @pytest.mark.asyncio
@@ -64,6 +67,7 @@ async def test_failure(job_with_adapter):
     fail_job_mock.assert_called_with(
         job_key=job_with_adapter.key, retries=job_with_adapter.retries - 1, message=message
     )
+    assert job_with_adapter.status == JobStatus.Failed
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Change `Job.status` when calling one of the state-changing functions.

## Changes

- `job.py`: Change `Job.status` when calling one of the state-changing functions.
- `job_teat.py`: Test that `Job.status` changes.

### Enhancements *(optional)*
`Job.status` now changes when calling one of the state-changing functions.

- [X] Unit tests
- [X] Documentation

Fixes #287