### PR TITLE
Update job.status to "RunningAfterDecorators" after the task completes

### DIFF
--- a/pyzeebe/job/job.py
+++ b/pyzeebe/job/job.py
@@ -40,6 +40,22 @@ class Job(object):
         self.status = status
         self.zeebe_adapter = zeebe_adapter
 
+    async def set_running_after_decorators_status(self) -> None:
+        """
+        RunningAfterDecorators status means that the task has been completed as intended and the after decorators will now run.
+
+        Raises:
+            NoZeebeAdapterError: If the job does not have a configured ZeebeAdapter
+            ZeebeBackPressureError: If Zeebe is currently in back pressure (too many requests)
+            ZeebeGatewayUnavailableError: If the Zeebe gateway is unavailable
+            ZeebeInternalError: If Zeebe experiences an internal error
+
+        """
+        if self.zeebe_adapter:
+            self.status = JobStatus.RunningAfterDecorators
+        else:
+            raise NoZeebeAdapterError()
+
     async def set_success_status(self) -> None:
         """
         Success status means that the job has been completed as intended.

--- a/pyzeebe/job/job_status.py
+++ b/pyzeebe/job/job_status.py
@@ -4,5 +4,6 @@ from enum import Enum
 class JobStatus(Enum):
     Running = "Running"
     Completed = "Completed"
+    RunningAfterDecorators = "RunningAfterDecorators"
     Failed = "Failed"
     ErrorThrown = "ErrorThrown"

--- a/pyzeebe/task/task_builder.py
+++ b/pyzeebe/task/task_builder.py
@@ -36,7 +36,7 @@ def build_job_handler(task_function: Function, task_config: TaskConfig) -> JobHa
         job.variables.update(original_return_value)
         job.variables.pop(task_config.job_parameter_name, None)
         await job.set_running_after_decorators_status()
-        await after_decorator_runner(job)
+        job = await after_decorator_runner(job)
         if succeeded:
             await job.set_success_status()
         return job

--- a/pyzeebe/task/task_builder.py
+++ b/pyzeebe/task/task_builder.py
@@ -35,7 +35,8 @@ def build_job_handler(task_function: Function, task_config: TaskConfig) -> JobHa
         original_return_value, succeeded = await run_original_task_function(prepared_task_function, task_config, job)
         job.variables.update(original_return_value)
         job.variables.pop(task_config.job_parameter_name, None)
-        job = await after_decorator_runner(job)
+        await job.set_running_after_decorators_status()
+        await after_decorator_runner(job)
         if succeeded:
             await job.set_success_status()
         return job

--- a/tests/unit/task/task_builder_test.py
+++ b/tests/unit/task/task_builder_test.py
@@ -4,6 +4,7 @@ from typing import Callable
 import pytest
 
 from pyzeebe import Job, TaskDecorator
+from pyzeebe.job.job_status import JobStatus
 from pyzeebe.task import task_builder
 from pyzeebe.task.task import Task
 from pyzeebe.task.task_config import TaskConfig
@@ -197,6 +198,17 @@ class TestBuildJobHandler:
         job = await job_handler(mocked_job_with_adapter)
 
         assert "x" in job.variables
+
+    @pytest.mark.asyncio
+    async def test_job_status_is_updated(
+        self,
+        task_config: TaskConfig,
+        mocked_job_with_adapter: Job,
+    ):
+        job_handler = task_builder.build_job_handler(self.function_with_job_parameter, task_config)
+        job = await job_handler(mocked_job_with_adapter)
+
+        assert job.status == JobStatus.RunningAfterDecorators
 
     @pytest.mark.asyncio
     async def test_job_parameter_is_injected(self, task_config: TaskConfig, mocked_job_with_adapter: Job):


### PR DESCRIPTION
## Changes

Sets job status to "RunningAfterDecorators" before the after decorators run, so that it is clear when the task has been completed

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #294
