### PR TITLE
corrects naming for an error

### DIFF
--- a/pyzeebe/errors/zeebe_errors.py
+++ b/pyzeebe/errors/zeebe_errors.py
@@ -15,7 +15,7 @@ class ZeebeInternalError(PyZeebeError):
     pass
 
 
-class UnkownGrpcStatusCodeError(PyZeebeError):
+class UnknownGrpcStatusCodeError(PyZeebeError):
     def __init__(self, grpc_error: grpc.aio.AioRpcError):
         super().__init__()
         self.grpc_error = grpc_error

--- a/pyzeebe/grpc_internals/zeebe_adapter_base.py
+++ b/pyzeebe/grpc_internals/zeebe_adapter_base.py
@@ -4,7 +4,7 @@ import grpc
 from zeebe_grpc.gateway_pb2_grpc import GatewayStub
 
 from pyzeebe.errors import (
-    UnkownGrpcStatusCodeError,
+    UnknownGrpcStatusCodeError,
     ZeebeBackPressureError,
     ZeebeGatewayUnavailableError,
     ZeebeInternalError,
@@ -51,4 +51,4 @@ def _create_pyzeebe_error_from_grpc_error(grpc_error: grpc.aio.AioRpcError) -> P
         return ZeebeGatewayUnavailableError()
     elif is_error_status(grpc_error, grpc.StatusCode.INTERNAL):
         return ZeebeInternalError()
-    return UnkownGrpcStatusCodeError(grpc_error)
+    return UnknownGrpcStatusCodeError(grpc_error)

--- a/tests/unit/grpc_internals/zeebe_adapter_base_test.py
+++ b/tests/unit/grpc_internals/zeebe_adapter_base_test.py
@@ -7,7 +7,7 @@ from pyzeebe.errors import (
     ZeebeGatewayUnavailableError,
     ZeebeInternalError,
 )
-from pyzeebe.errors.zeebe_errors import UnkownGrpcStatusCodeError
+from pyzeebe.errors.zeebe_errors import UnknownGrpcStatusCodeError
 from pyzeebe.grpc_internals.zeebe_adapter_base import ZeebeAdapterBase
 
 
@@ -56,7 +56,7 @@ class TestHandleRpcError:
         zeebe_adapter: ZeebeAdapterBase,
     ):
         error = grpc.aio.AioRpcError("FakeGrpcStatus", None, None)
-        with pytest.raises(UnkownGrpcStatusCodeError):
+        with pytest.raises(UnknownGrpcStatusCodeError):
             await zeebe_adapter._handle_grpc_error(error)
 
     async def test_closes_after_retries_exceeded(self, zeebe_adapter: ZeebeAdapterBase):


### PR DESCRIPTION


Description of PR...

## Changes

- Changes ~UnkownGrpcStatusCodeError~ to **Unk<sup>n</sup>ownGrpcStatusCodeError**

## API Updates

### Deprecations

This may affect old codebases having **UnkownGrpcStatusCodeError** naming convention.

### Enhancements

Better understanding to guess the error precisely, instead to spell it incorrectly in code.
Also the unit tests are updated with changes

## Checklist

- [x] Unit tests
- [ ] Documentation

## References

This potentially fixes #307 
