### PR TITLE
Add stack trace when decorator fails

### DIFF
--- a/pyzeebe/task/task_builder.py
+++ b/pyzeebe/task/task_builder.py
@@ -82,5 +82,5 @@ async def run_decorator(decorator: AsyncTaskDecorator, job: Job) -> Job:
     try:
         return await decorator(job)
     except Exception as e:
-        logger.warning("Failed to run decorator %s. Exception: %s", decorator, e)
+        logger.warning("Failed to run decorator %s. Exception: %s", decorator, e, exc_info=True)
         return job


### PR DESCRIPTION
We log each time a decorator fails. This pr adds a stack trace to that log

## Changes

- Log stack trace of decorator failure

## API Updates

### New Features 

None

### Deprecations 

None

## Checklist

- [ ] Unit tests
- [ ] Documentation

## References

Fixes #334 