### PR TITLE
Pass task result to task after-callback

### DIFF
--- a/pyzeebe/job/job.py
+++ b/pyzeebe/job/job.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from pyzeebe.job.job_status import JobStatus
 from pyzeebe.types import Headers, Variables
@@ -25,6 +25,10 @@ class Job:
     variables: Variables
     tenant_id: Optional[str] = None
     status: JobStatus = JobStatus.Running
+    task_result = None
+
+    def set_task_result(self, task_result: Any) -> None:
+        object.__setattr__(self, "task_result", task_result)
 
     def _set_status(self, value: JobStatus) -> None:
         object.__setattr__(self, "status", value)

--- a/pyzeebe/task/task_builder.py
+++ b/pyzeebe/task/task_builder.py
@@ -41,6 +41,7 @@ def build_job_handler(task_function: Function[..., Any], task_config: TaskConfig
         return_variables, succeeded = await run_original_task_function(
             prepared_task_function, task_config, job, job_controller
         )
+        job.set_task_result(return_variables)
         await job_controller.set_running_after_decorators_status()
         job = await after_decorator_runner(job)
         if succeeded:

--- a/tests/unit/task/task_builder_test.py
+++ b/tests/unit/task/task_builder_test.py
@@ -208,6 +208,29 @@ class TestBuildJobHandler:
         task_config.after.pop().assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_after_decorator_can_access_task_result(
+        self,
+        task_config: TaskConfig,
+        job: Job,
+        mocked_job_controller: JobController,
+    ):
+        async def task_function():
+            return {"result": 1}
+
+        self.task_result = dict()
+
+        async def after_decorator(job: Job):
+            self.task_result = job.task_result
+            return job
+
+        task_config.after.append(after_decorator)
+        job_handler = task_builder.build_job_handler(task_function, task_config)
+
+        await job_handler(job, mocked_job_controller)
+
+        assert self.task_result == {"result": 1}
+
+    @pytest.mark.asyncio
     async def test_failing_decorator_continues(
         self,
         original_task_function: Callable,


### PR DESCRIPTION
This allows after-task callbacks to access the task result.

This is useful for example when the callback wants to log the task result.

### New Features

The `Job` class now has new property `task_result` that contains the task result (returned variables) after the task has been executed.

### Deprecations

None

## Checklist

- [✅] Unit tests
- [❔] Documentation
