### PR TITLE
feat: get_channel_options from dict to tuple

### DIFF
--- a/pyzeebe/channel/camunda_cloud_channel.py
+++ b/pyzeebe/channel/camunda_cloud_channel.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import grpc
 from oauthlib import oauth2
@@ -6,6 +6,7 @@ from requests import HTTPError
 from requests_oauthlib import OAuth2Session
 
 from pyzeebe.channel.channel_options import get_channel_options
+from pyzeebe.credentials.typing import ChannelArgumentType
 from pyzeebe.errors import (
     InvalidCamundaCloudCredentialsError,
     InvalidOAuthCredentialsError,
@@ -17,7 +18,7 @@ def create_camunda_cloud_channel(
     client_secret: str,
     cluster_id: str,
     region: str = "bru-2",
-    channel_options: Optional[Dict[str, Any]] = None,
+    channel_options: Optional[ChannelArgumentType] = None,
 ) -> grpc.aio.Channel:
     """
     Create channel connected to a Camunda Cloud cluster
@@ -40,7 +41,7 @@ def create_camunda_cloud_channel(
     return grpc.aio.secure_channel(
         f"{cluster_id}.{region}.zeebe.camunda.io:443",
         channel_credentials,
-        options=get_channel_options(channel_options or {}),
+        options=get_channel_options(channel_options),
     )
 
 

--- a/pyzeebe/channel/camunda_cloud_channel.py
+++ b/pyzeebe/channel/camunda_cloud_channel.py
@@ -6,11 +6,11 @@ from requests import HTTPError
 from requests_oauthlib import OAuth2Session
 
 from pyzeebe.channel.channel_options import get_channel_options
-from pyzeebe.credentials.typing import ChannelArgumentType
 from pyzeebe.errors import (
     InvalidCamundaCloudCredentialsError,
     InvalidOAuthCredentialsError,
 )
+from pyzeebe.types import ChannelArgumentType
 
 
 def create_camunda_cloud_channel(
@@ -28,7 +28,8 @@ def create_camunda_cloud_channel(
         client_secret (str): The client secret provided by Camunda Cloud
         cluster_id (str): The zeebe cluster id to connect to
         region (str): The cluster's region. Defaults to bru-2
-        channel_options (Optional[Dict], optional): GRPC channel options. See https://grpc.github.io/grpc/python/glossary.html
+        channel_options (Optional[Dict], optional): GRPC channel options.
+            See https://grpc.github.io/grpc/python/glossary.html
 
     Returns:
         grpc.aio.Channel: A GRPC Channel connected to the Zeebe gateway.

--- a/pyzeebe/channel/channel_options.py
+++ b/pyzeebe/channel/channel_options.py
@@ -8,27 +8,34 @@ Time between keepalive pings. Following the official Zeebe Java/Go client, sendi
 https://docs.camunda.io/docs/product-manuals/zeebe/deployment-guide/operations/setting-up-a-cluster/#keep-alive-intervals
 """
 
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional
 
-GRPC_CHANNEL_OPTIONS = {"grpc.keepalive_time_ms": 45_000}
+from pyzeebe.credentials.typing import ChannelArgumentType
+
+GRPC_CHANNEL_OPTIONS_DEFAULT: ChannelArgumentType = (("grpc.keepalive_time_ms", 45_000),)
 
 
-def get_channel_options(options: Optional[Dict[str, Any]] = None) -> Tuple[Tuple[str, Any], ...]:
+def get_channel_options(options: Optional[ChannelArgumentType] = None) -> ChannelArgumentType:
     """
-    Convert options dict to tuple in expected format for creating the gRPC channel
+    Get default channel options for creating the gRPC channel.
 
     Args:
-        options (Dict[str, Any]): A key/value representation of `gRPC channel arguments_`.
+        options (Optional[ChannelArgumentType]): A tuple of gRPC channel arguments tuple.
+            e.g. (("grpc.keepalive_time_ms", 45_000),)
             Default: None (will use library defaults)
+            See https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
 
     Returns:
-        Tuple[Tuple[str, Any], ...]: Options for the gRPC channel
-
-    .. _gRPC channel arguments:
-        https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
+        ChannelArgumentType: Options for the gRPC channel
     """
-    if options:
-        options = {**GRPC_CHANNEL_OPTIONS, **options}
-    else:
-        options = GRPC_CHANNEL_OPTIONS
-    return tuple((k, v) for k, v in options.items())
+    if options is not None:
+        existing = set()
+        _options = []
+
+        for a, b in (*options, *GRPC_CHANNEL_OPTIONS_DEFAULT):
+            if a not in existing:  # NOTE: Remove duplicates, fist one wins
+                existing.add(a)
+                _options.append((a, b))
+
+        return tuple(_options)  # (*options, GRPC_CHANNEL_OPTIONS)
+    return GRPC_CHANNEL_OPTIONS_DEFAULT

--- a/pyzeebe/channel/channel_options.py
+++ b/pyzeebe/channel/channel_options.py
@@ -10,7 +10,7 @@ https://docs.camunda.io/docs/product-manuals/zeebe/deployment-guide/operations/s
 
 from typing import Optional
 
-from pyzeebe.credentials.typing import ChannelArgumentType
+from pyzeebe.types import ChannelArgumentType
 
 GRPC_CHANNEL_OPTIONS_DEFAULT: ChannelArgumentType = (("grpc.keepalive_time_ms", 45_000),)
 

--- a/pyzeebe/channel/insecure_channel.py
+++ b/pyzeebe/channel/insecure_channel.py
@@ -1,13 +1,14 @@
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import grpc
 
 from pyzeebe.channel.channel_options import get_channel_options
 from pyzeebe.channel.utils import create_address
+from pyzeebe.credentials.typing import ChannelArgumentType
 
 
 def create_insecure_channel(
-    hostname: Optional[str] = None, port: Optional[int] = None, channel_options: Optional[Dict[str, Any]] = None
+    hostname: Optional[str] = None, port: Optional[int] = None, channel_options: Optional[ChannelArgumentType] = None
 ) -> grpc.aio.Channel:
     """
     Create an insecure channel

--- a/pyzeebe/channel/insecure_channel.py
+++ b/pyzeebe/channel/insecure_channel.py
@@ -4,7 +4,7 @@ import grpc
 
 from pyzeebe.channel.channel_options import get_channel_options
 from pyzeebe.channel.utils import create_address
-from pyzeebe.credentials.typing import ChannelArgumentType
+from pyzeebe.types import ChannelArgumentType
 
 
 def create_insecure_channel(
@@ -16,7 +16,8 @@ def create_insecure_channel(
     Args:
         hostname (Optional[str], optional): Zeebe gateway hostname
         port (Optional[int], optional): Zeebe gateway port
-        channel_options (Optional[Dict], optional): GRPC channel options. See https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
+        channel_options (Optional[Dict], optional): GRPC channel options.
+            See https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
 
     Returns:
         grpc.aio.Channel: A GRPC Channel connected to the Zeebe gateway.

--- a/pyzeebe/channel/secure_channel.py
+++ b/pyzeebe/channel/secure_channel.py
@@ -4,7 +4,7 @@ import grpc
 
 from pyzeebe.channel.channel_options import get_channel_options
 from pyzeebe.channel.utils import create_address
-from pyzeebe.credentials.typing import ChannelArgumentType
+from pyzeebe.types import ChannelArgumentType
 
 
 def create_secure_channel(
@@ -19,8 +19,10 @@ def create_secure_channel(
     Args:
         hostname (Optional[str], optional): Zeebe gateway hostname
         port (Optional[int], optional): Zeebe gateway port
-        channel_options (Optional[Dict], optional): GRPC channel options. See https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
-        channel_credentials (Optional[grpc.ChannelCredentials]): Channel credentials to use. Will use grpc.ssl_channel_credentials() if not provided.
+        channel_options (Optional[Dict], optional): GRPC channel options.
+            See https://grpc.github.io/grpc/python/glossary.html#term-channel_arguments
+        channel_credentials (Optional[grpc.ChannelCredentials]): Channel credentials to use.
+            Will use grpc.ssl_channel_credentials() if not provided.
 
     Returns:
         grpc.aio.Channel: A GRPC Channel connected to the Zeebe gateway.

--- a/pyzeebe/channel/secure_channel.py
+++ b/pyzeebe/channel/secure_channel.py
@@ -1,15 +1,16 @@
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import grpc
 
 from pyzeebe.channel.channel_options import get_channel_options
 from pyzeebe.channel.utils import create_address
+from pyzeebe.credentials.typing import ChannelArgumentType
 
 
 def create_secure_channel(
     hostname: Optional[str] = None,
     port: Optional[int] = None,
-    channel_options: Optional[Dict[str, Any]] = None,
+    channel_options: Optional[ChannelArgumentType] = None,
     channel_credentials: Optional[grpc.ChannelCredentials] = None,
 ) -> grpc.aio.Channel:
     """

--- a/pyzeebe/credentials/typing.py
+++ b/pyzeebe/credentials/typing.py
@@ -1,4 +1,7 @@
-from typing import Protocol, Tuple, Union
+from typing import Any, Protocol, Sequence, Tuple, Union
+
+ChannelArgumentType = Sequence[Tuple[str, Any]]
+# from grpc.aio._typing import ChannelArgumentType  # type: ignore[import-untyped]
 
 AuthMetadata = Tuple[Tuple[str, Union[str, bytes]], ...]
 

--- a/pyzeebe/credentials/typing.py
+++ b/pyzeebe/credentials/typing.py
@@ -1,7 +1,4 @@
-from typing import Any, Protocol, Sequence, Tuple, Union
-
-ChannelArgumentType = Sequence[Tuple[str, Any]]
-# from grpc.aio._typing import ChannelArgumentType  # type: ignore[import-untyped]
+from typing import Protocol, Tuple, Union
 
 AuthMetadata = Tuple[Tuple[str, Union[str, bytes]], ...]
 

--- a/pyzeebe/types.py
+++ b/pyzeebe/types.py
@@ -1,6 +1,8 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence, Tuple
 
 from typing_extensions import TypeAlias
 
 Headers: TypeAlias = Mapping[str, Any]
 Variables: TypeAlias = Mapping[str, Any]
+
+ChannelArgumentType: TypeAlias = Sequence[Tuple[str, Any]]

--- a/tests/unit/channel/channel_options_test.py
+++ b/tests/unit/channel/channel_options_test.py
@@ -2,23 +2,23 @@ from pyzeebe.channel.channel_options import get_channel_options
 
 
 def test_get_channel_options_returns_tuple_of_tuple_with_options():
-    assert get_channel_options() == (("grpc.keepalive_time_ms", 45000),)
+    assert get_channel_options() == (("grpc.keepalive_time_ms", 45_000),)
 
 
 def test_overrides_default_values_if_provided():
-    grpc_options = {"grpc.keepalive_time_ms": 4000}
+    grpc_options = (("grpc.keepalive_time_ms", 4_000),)
 
-    assert get_channel_options(grpc_options) == (("grpc.keepalive_time_ms", 4000),)
+    assert get_channel_options(grpc_options) == (("grpc.keepalive_time_ms", 4_000),)
 
 
 def test_adds_custom_options():
-    grpc_options = {
-        "grpc.keepalive_timeout_ms": 120000,
-        "grpc.http2.min_time_between_pings_ms": 60000,
-    }
+    grpc_options = (
+        ("grpc.keepalive_timeout_ms", 120_000),
+        ("grpc.http2.min_time_between_pings_ms", 60_000),
+    )
 
     assert get_channel_options(grpc_options) == (
-        ("grpc.keepalive_time_ms", 45000),
-        ("grpc.keepalive_timeout_ms", 120000),
-        ("grpc.http2.min_time_between_pings_ms", 60000),
+        ("grpc.keepalive_timeout_ms", 120_000),
+        ("grpc.http2.min_time_between_pings_ms", 60_000),
+        ("grpc.keepalive_time_ms", 45_000),
     )


### PR DESCRIPTION
Change grpc options (channel_arguments) from dict to tuple

## Changes

- get_channel_options type from `dict[str, Any]` -> `ChannelArgumentType = Sequence[Tuple[str, Any]]`
- dependend channel creation methods

## API Updates

### New Features *(required)*

The function for defining default grpc [channel_arguments](https://grpc.github.io/grpc/python/glossary.html)

### Deprecations *(required)*


### Enhancements *(optional)*

When changing between librarys users can define the channel options like in the official grpc package itself.
See https://grpc.github.io/grpc/python/glossary.html.

## Checklist

- [x] Unit tests
- [x] Documentation

## References

https://grpc.github.io/grpc/python/glossary.html
https://github.com/grpc/grpc/blob/v1.64.x/include/grpc/impl/channel_arg_names.h

Resolves #482
