### PR TITLE
Pass all variables to task when `TaskConfig.variables_to_fetch==[]`

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -74,14 +74,14 @@ def first_active_job(task, job_from_task, grpc_servicer) -> str:
 
 
 @pytest.fixture
-def task_config(task_type):
+def task_config(task_type, variables_to_fetch=None):
     return TaskConfig(
         type=task_type,
         exception_handler=AsyncMock(),
         timeout_ms=10000,
         max_jobs_to_activate=32,
         max_running_jobs=32,
-        variables_to_fetch=[],
+        variables_to_fetch=variables_to_fetch or [],
         single_value=False,
         variable_name="",
         before=[],

--- a/tests/unit/task/task_builder_test.py
+++ b/tests/unit/task/task_builder_test.py
@@ -1,9 +1,11 @@
 import copy
 from typing import Callable
+from unittest.mock import MagicMock
 
 import pytest
 
 from pyzeebe import Job, JobController, TaskDecorator
+from pyzeebe.function_tools.parameter_tools import get_parameters_from_function
 from pyzeebe.job.job_status import JobStatus
 from pyzeebe.task import task_builder
 from pyzeebe.task.task import Task
@@ -108,29 +110,41 @@ class TestBuildJobHandler:
     async def test_parameters_are_provided_to_task_with_only_job(
         self, original_task_function: Callable, task_config: TaskConfig, mocked_job_controller: JobController
     ):
+        task_with_only_job_called = False
+
+        def task_with_only_job(job: Job):
+            nonlocal task_with_only_job_called
+            task_with_only_job_called = True
+
         job = random_job(variables={"x": 1})
         task_config.job_parameter_name = "job"
         task_config.variables_to_fetch = []
 
-        job_handler = task_builder.build_job_handler(original_task_function, task_config)
+        job_handler = task_builder.build_job_handler(task_with_only_job, task_config)
 
         await job_handler(job, mocked_job_controller)
 
-        original_task_function.assert_called_with(job=job)
+        assert task_with_only_job_called, "Task was called ok"
 
     @pytest.mark.asyncio
     async def test_parameters_are_provided_to_task_with_arg_and_job(
-        self, original_task_function: Callable, task_config: TaskConfig, mocked_job_controller: JobController
+        self, task_config: TaskConfig, mocked_job_controller: JobController
     ):
+        call_params = None
+
+        def task_with_arg_and_job(job: Job, x):
+            nonlocal call_params
+            call_params = {"job": job, "x": x}
+
         job = random_job(variables={"x": 1})
         task_config.job_parameter_name = "job"
         task_config.variables_to_fetch = ["x"]
 
-        job_handler = task_builder.build_job_handler(original_task_function, task_config)
+        job_handler = task_builder.build_job_handler(task_with_arg_and_job, task_config)
 
         await job_handler(job, mocked_job_controller)
 
-        original_task_function.assert_called_with(job=job, x=1)
+        assert call_params == {"job": job, "x": 1}
 
     @pytest.mark.asyncio
     async def test_variables_are_added_to_result(
@@ -176,6 +190,27 @@ class TestBuildJobHandler:
         original_task_function.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_empty_variables_to_fetch_results_in_all_vars_passed_to_task(
+        self, mocked_job_controller: JobController, task_config: TaskConfig
+    ):
+        task_config.variables_to_fetch = []
+        task_config.job_parameter_name = "job"
+
+        call_params = None
+
+        def task_with_params(job: Job, *args, **kwargs):
+            nonlocal call_params
+            call_params = {"job": job, "args": args, "kwargs": kwargs}
+
+        job = random_job(variables={"a": 1, "b": 2})
+
+        job_handler = task_builder.build_job_handler(task_with_params, task_config)
+
+        await job_handler(job, mocked_job_controller)
+
+        assert call_params == {"job": job, "args": (), "kwargs": {"a": 1, "b": 2}}
+
+    @pytest.mark.asyncio
     async def test_before_decorator_called(
         self,
         original_task_function: Callable,
@@ -217,10 +252,11 @@ class TestBuildJobHandler:
         async def task_function():
             return {"result": 1}
 
-        self.task_result = dict()
+        task_result = dict()
 
         async def after_decorator(job: Job):
-            self.task_result = job.task_result
+            nonlocal task_result
+            task_result = job.task_result
             return job
 
         task_config.after.append(after_decorator)
@@ -228,7 +264,7 @@ class TestBuildJobHandler:
 
         await job_handler(job, mocked_job_controller)
 
-        assert self.task_result == {"result": 1}
+        assert task_result == {"result": 1}
 
     @pytest.mark.asyncio
     async def test_failing_decorator_continues(


### PR DESCRIPTION
Pass all variables to task when `TaskConfig.variables_to_fetch==[]`
Because empty list in `TaskConfig.variables_to_fetch` results in all variables being fetched from Zeebe and it is reasonably expected that they will also be passed to the task.

\+ use nonlocal variables instead of instance properties in tests  to avoid potential conflicts between tests

## Changes

- Pass all job variables to task when expected
- Use nonlocal variables in tests to improve encapsulation

## API Updates

### New Features *(required)*

It is now possible to use `*args, **kwargs` in task and receive all variables there.

### Deprecations *(required)*

N/A

### Enhancements *(optional)*

N/A

## Checklist

- [✅] Unit tests
- [❔] Documentation

## References

Broken in commit related to #404 