### PR TITLE
add support for raising NonRecoveredDecoratorError to stop job execution

### DIFF
--- a/pyzeebe/errors/decorator_errors.py
+++ b/pyzeebe/errors/decorator_errors.py
@@ -1,0 +1,3 @@
+class NonRecoverableDecoratorError(Exception):
+    "Raised when a decorator encounters a critical error and the job should fail."
+    pass

--- a/pyzeebe/task/task_builder.py
+++ b/pyzeebe/task/task_builder.py
@@ -9,6 +9,7 @@ from typing import Any, TypeVar
 from typing_extensions import ParamSpec
 
 from pyzeebe import Job
+from pyzeebe.errors.decorator_errors import NonRecoverableDecoratorError
 from pyzeebe.function_tools import DictFunction, Function
 from pyzeebe.function_tools.async_tools import asyncify, is_async_function
 from pyzeebe.function_tools.dict_tools import convert_to_dict_function
@@ -118,6 +119,8 @@ def create_decorator_runner(decorators: Sequence[AsyncTaskDecorator]) -> Decorat
 async def run_decorator(decorator: AsyncTaskDecorator, job: Job) -> Job:
     try:
         return await decorator(job)
+    except NonRecoverableDecoratorError:
+        raise
     except Exception as e:
         logger.warning("Failed to run decorator %s. Exception: %s", decorator, e, exc_info=True)
         return job

--- a/pyzeebe/worker/job_executor.py
+++ b/pyzeebe/worker/job_executor.py
@@ -9,6 +9,7 @@ from pyzeebe.grpc_internals.zeebe_adapter import ZeebeAdapter
 from pyzeebe.job.job import Job, JobController
 from pyzeebe.task.task import Task
 from pyzeebe.worker.task_state import TaskState
+from pyzeebe.errors.decorator_errors import NonRecoverableDecoratorError
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,9 @@ class JobExecutor:
     async def execute_one_job(self, job: Job, job_controller: JobController) -> None:
         try:
             await self.task.job_handler(job, job_controller)
+        except NonRecoverableDecoratorError as error:
+            logger.error(f"Non-recoverable decorator error in job %s: %s", job.type, error)
+            raise
         except JobAlreadyDeactivatedError as error:
             logger.warning("Job was already deactivated. Job key: %s", error.job_key)
 

--- a/pyzeebe/worker/task_router.py
+++ b/pyzeebe/worker/task_router.py
@@ -14,6 +14,7 @@ from pyzeebe.task.task import Task
 from pyzeebe.task.task_config import TaskConfig
 from pyzeebe.task.types import TaskDecorator
 
+
 P = ParamSpec("P")
 R = TypeVar("R")
 RD = TypeVar("RD", bound=Optional[dict[str, Any]])


### PR DESCRIPTION
Description of PR...

### Summary
This PR adds support for failing job execution early when a decorator raises a `NonRecoverableDecoratorError`.

### Motivation
Currently, when a decorator fails, the error is logged but the job continues running. In some cases, this is undesirable.
This change allows developers to define non-recoverable decorator errors that immediately fail the job.

### Changes
- Defined a new exception: `NonRecoverableDecoratorError` to explicitly represent non-recoverable decorator errors.
- Modified `JobExecutor.execute_one_job` (in `pyzeebe/worker/job_executor.py`) to:
  - Catch `NonRecoverableDecoratorError` raised during job execution.
  - Log the error with `logger.error(...)`.
  - Re-raise the error to allow Zeebe to fail the job early and stop further processing.
- Confirmed that decorators defined in 'before' and 'after' are executed via the 'run_decorator' functions. Previously, if a decorator raised an exception, it was caught and only logged - the job continued as if nothing happened. 
- This change allows custom user-defined decorators to intentionally fail a job by raising `NonRecoverableDecoratorError` from within a decorator. 

This does **not** modify existing public APIs and maintains full backward compatibility. Users who don't use this new exception will see no change in behavior.

Fixes: #149