### PR TITLE
Fixes incorrect task "timeout" parameter in the documentation

### DIFF
--- a/docs/worker_tasks.rst
+++ b/docs/worker_tasks.rst
@@ -94,11 +94,11 @@ This tells Zeebe that the job failed. The job will then be retried (if configure
 
 Task timeout
 ------------
-When creating a task one of the parameters we can specify is ``timeout``.
+When creating a task one of the parameters we can specify is ``timeout_ms``.
 
 .. code-block:: python
 
-    @worker.task(task_type="my_task", timeout=20000)
+    @worker.task(task_type="my_task", timeout_ms=20000)
     def my_task(input: str):
         return {"output": f"Hello World, {input}!"}
 


### PR DESCRIPTION
Fixes incorrect task "timeout" parameter in the documentation

## Changes

- Task timeout parameter changed from "timeout" to "timeout_ms" (in docs)

## API Updates

### New Features *(required)*

No changes/ Only documentation has changed

### Deprecations *(required)*

No changes/ Only documentation has changed

### Enhancements *(optional)*

No changes/ Only documentation has changed

## Checklist

- [x] Unit tests
- [x] Documentation

## References

Fixes #660