### PR TITLE
fix: retain strong refs to running job tasks in JobExecutor

### DIFF
--- a/pyzeebe/worker/job_executor.py
+++ b/pyzeebe/worker/job_executor.py
@@ -22,11 +22,14 @@ class JobExecutor:
         self.task_state = task_state
         self.stop_event = asyncio.Event()
         self.zeebe_adapter = zeebe_adapter
+        self.running_tasks: set[asyncio.Task] = set()
 
     async def execute(self) -> None:
         while self.should_execute():
             job = await self.get_next_job()
             task = asyncio.create_task(self.execute_one_job(job, JobController(job, self.zeebe_adapter)))
+            self.running_tasks.add(task)
+            task.add_done_callback(self.running_tasks.discard)
             task.add_done_callback(create_job_callback(self, job))
 
     async def get_next_job(self) -> Job:

--- a/tests/unit/worker/job_executor_test.py
+++ b/tests/unit/worker/job_executor_test.py
@@ -38,6 +38,38 @@ class TestExecuteOneJob:
 
 
 @pytest.mark.anyio
+class TestExecute:
+    async def test_retains_strong_reference_to_running_tasks(
+        self, job_executor: JobExecutor, job_from_task: Job, task: Task
+    ):
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_handler(job: Job, job_controller: JobController) -> None:
+            started.set()
+            await release.wait()
+
+        task.job_handler = slow_handler
+        await job_executor.jobs.put(job_from_task)
+
+        execute_task = asyncio.create_task(job_executor.execute())
+        try:
+            await started.wait()
+
+            assert len(job_executor.running_tasks) == 1
+            running = next(iter(job_executor.running_tasks))
+            assert not running.done()
+
+            release.set()
+            await running
+            assert len(job_executor.running_tasks) == 0
+        finally:
+            execute_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await execute_task
+
+
+@pytest.mark.anyio
 class TestGetNextJob:
     async def test_returns_expected_job(self, job_executor: JobExecutor, job_from_task: Job):
         await job_executor.jobs.put(job_from_task)


### PR DESCRIPTION
Prevent asyncio GC from destroying in-flight `create_task` jobs before complete/fail is sent to Zeebe.

## Changes

- Keep strong references to running job tasks in `JobExecutor.running_tasks`
- Remove each task from the set via `done_callback` when the job finishes
- Add a unit test that asserts a running task is retained until completion

## API Updates

### New Features *(required)*

None.

### Deprecations *(required)*

None.

### Enhancements *(optional)*

`JobExecutor` now keeps a `running_tasks` set so asyncio does not garbage-collect pending job tasks. Without a strong reference, the event loop only holds weak refs to tasks; under load a task can be destroyed mid-execution (`Task was destroyed but it is pending!`), leaving the Zeebe job ACTIVATED with neither `complete` nor `fail`.

## Checklist

- [x] Unit tests
- [ ] Documentation

## References

- https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task  
  (“Save a reference to the result of this function, to avoid a task disappearing mid-execution.”)